### PR TITLE
Keep trivial sums/products unevaluated

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -83,8 +83,6 @@ class Add(Expr, AssocOp):
         Applies associativity, all terms are commutable with respect to
         addition.
 
-        NB: the removal of 0 is already handled by AssocOp.__new__
-
         See also
         ========
 

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -997,6 +997,8 @@ class Basic(with_metaclass(ManagedProperties)):
                     nonnumber = self.func(*nonnumber)
                     if coeff is S.One:
                         return nonnumber
+                    elif nonnumber is S.One:
+                        return coeff
                     else:
                         return self.func(coeff, nonnumber, evaluate=False)
                 return rv

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -168,10 +168,7 @@ class Mul(Expr, AssocOp):
               details of Mul and flatten which may change at any time. Therefore,
               you should only consider them when your code is highly performance
               sensitive.
-
-              Removal of 1 from the sequence is already handled by AssocOp.__new__.
         """
-
         rv = None
         if len(seq) == 2:
             a, b = seq
@@ -182,8 +179,11 @@ class Mul(Expr, AssocOp):
                 r, b = b.as_coeff_Mul()
                 if b.is_Add:
                     if r is not S.One:  # 2-arg hack
-                        # leave the Mul as a Mul
-                        rv = [cls(a*r, b, evaluate=False)], [], None
+                        if a*r is S.One:
+                            rv = [b], [], None
+                        else:
+                            # leave the Mul as a Mul
+                            rv = [cls(a*r, b, evaluate=False)], [], None
                     elif b.is_commutative:
                         if a is S.One:
                             rv = [b], [], None

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -358,6 +358,8 @@ class Number(AtomicExpr):
 
     @_sympifyit('other', NotImplemented)
     def __add__(self, other):
+        if self is S.Zero:
+            return other
         if isinstance(other, Number):
             if other is S.NaN:
                 return S.NaN
@@ -380,6 +382,8 @@ class Number(AtomicExpr):
 
     @_sympifyit('other', NotImplemented)
     def __mul__(self, other):
+        if self is S.One:
+            return other
         if isinstance(other, Number):
             if other is S.NaN:
                 return S.NaN

--- a/sympy/core/operations.py
+++ b/sympy/core/operations.py
@@ -28,10 +28,11 @@ class AssocOp(Basic):
     def __new__(cls, *args, **options):
         from sympy import Order
         args = list(map(_sympify, args))
-        args = [a for a in args if a is not cls.identity]
 
         if not options.pop('evaluate', global_evaluate[0]):
             return cls._from_args(args)
+        else:
+            args = [a for a in args if a is not cls.identity]
 
         if len(args) == 0:
             return cls.identity

--- a/sympy/core/tests/test_arit.py
+++ b/sympy/core/tests/test_arit.py
@@ -1329,10 +1329,10 @@ def test_suppressed_evaluation():
     c = Pow(3, 2, evaluate=False)
     assert a != 6
     assert a.func is Add
-    assert a.args == (3, 2)
+    assert a.args == (0, 3, 2)
     assert b != 6
     assert b.func is Mul
-    assert b.args == (3, 2)
+    assert b.args == (1, 3, 2)
     assert c != 9
     assert c.func is Pow
     assert c.args == (3, 2)

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -1281,6 +1281,8 @@ class PrettyPrinter(Printer):
         else:
             args = product.args
 
+        multiple_ones = len([x for x in args if x == S.One]) > 1
+
         # Gather terms for numerator/denominator
         for item in args:
             if item.is_commutative and item.is_Pow and item.exp.is_Rational and item.exp.is_negative:
@@ -1289,8 +1291,8 @@ class PrettyPrinter(Printer):
                 else:
                     b.append(Pow(item.base, -item.exp))
             elif item.is_Rational and item is not S.Infinity:
-                if item.p != 1:
-                    a.append( Rational(item.p) )
+                if item.p != 1 or multiple_ones:
+                    a.append(Rational(item.p))
                 if item.q != 1:
                     b.append( Rational(item.q) )
             else:

--- a/sympy/printing/pretty/tests/test_pretty.py
+++ b/sympy/printing/pretty/tests/test_pretty.py
@@ -4801,6 +4801,15 @@ def test_Tr():
 def test_pretty_Add():
     eq = Mul(-2, x - 2, evaluate=False) + 5
     assert pretty(eq) == '-2*(x - 2) + 5'
+    eq = Add(0, 0, evaluate=False)
+    assert pretty(eq) == '0 + 0'
+    assert upretty(eq) == u('0 + 0')
+
+
+def test_pretty_Mul():
+    eq = Mul(1, 1, evaluate=False)
+    assert pretty(eq) == '1*1'
+    assert upretty(eq) == u('1⋅1')
 
 
 def test_issue_7179():

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -263,6 +263,8 @@ class StrPrinter(Printer):
             # use make_args in case expr was something like -x -> x
             args = Mul.make_args(expr)
 
+        multiple_ones = len([x for x in args if x == S.One]) > 1
+
         # Gather args for numerator/denominator
         for item in args:
             if item.is_commutative and item.is_Pow and item.exp.is_Rational and item.exp.is_negative:
@@ -271,7 +273,7 @@ class StrPrinter(Printer):
                 else:
                     b.append(Pow(item.base, -item.exp))
             elif item.is_Rational and item is not S.Infinity:
-                if item.p != 1:
+                if item.p != 1 or multiple_ones:
                     a.append(Rational(item.p))
                 if item.q != 1:
                     b.append(Rational(item.q))

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -1305,6 +1305,13 @@ def test_Mul():
     assert latex(e)  == r'- 2 x - 2'
     e = Mul(2, x + 1)
     assert latex(e)  == r'2 x + 2'
+    e = Mul(1, 1, evaluate=False)
+    assert latex(e)  == r'1 \cdot 1'
+
+
+def test_Add():
+    e = Add(0, 0, evaluate=False)
+    assert latex(e)  == r'0 + 0'
 
 
 def test_Pow():

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -1,6 +1,6 @@
 from __future__ import division
 
-from sympy import (Abs, Catalan, cos, Derivative, E, EulerGamma, exp,
+from sympy import (Add, Mul, Abs, Catalan, cos, Derivative, E, EulerGamma, exp,
     factorial, factorial2, Function, GoldenRatio, I, Integer, Integral,
     Interval, Lambda, Limit, Matrix, nan, O, oo, pi, Rational, Float, Rel,
     S, sin, SparseMatrix, sqrt, summation, Sum, Symbol, symbols, Wild,
@@ -52,6 +52,7 @@ def test_Add():
     assert str(x - z*y**2*z*w) == "-w*y**2*z**2 + x"
     assert str(x - 1*y*x*y) == "-x*y**2 + x"
     assert str(sin(x).series(x, 0, 15)) == "x - x**3/6 + x**5/120 - x**7/5040 + x**9/362880 - x**11/39916800 + x**13/6227020800 + O(x**15)"
+    assert str(Add(0, 0, evaluate=False)) == "0 + 0"
 
 
 def test_Catalan():
@@ -218,6 +219,7 @@ def test_Mul():
     assert str(cc2*Rational(2)) == '2*CustomClass2()'
     assert str(cc2*Rational(2)*cc1) == '2*CustomClass1()*CustomClass2()'
     assert str(cc1*Rational(2)*cc2) == '2*CustomClass1()*CustomClass2()'
+    assert str(Mul(1, 1, evaluate=False)) == '1*1'
 
 
 def test_NaN():


### PR DESCRIPTION
```python
In [1]: Add(0, 0, evaluate=False)
Out[1]: 0 + 0

In [2]: Mul(1, 1, evaluate=False)
Out[2]: 1⋅1

In [3]: print(Add(0, 0, evaluate=False))
0 + 0

In [4]: print(Mul(1, 1, evaluate=False))
1*1
```