### PR TITLE
Fix "flip" of arguments in relational expressions

### DIFF
--- a/sympy/concrete/expr_with_limits.py
+++ b/sympy/concrete/expr_with_limits.py
@@ -4,7 +4,7 @@ from sympy.core.mul import Mul
 from sympy.core.relational import Equality
 from sympy.sets.sets import Interval
 from sympy.core.singleton import S
-from sympy.core.symbol import Symbol
+from sympy.core.symbol import Dummy, Symbol
 from sympy.core.sympify import sympify
 from sympy.core.compatibility import is_sequence
 from sympy.core.containers import Tuple
@@ -22,7 +22,7 @@ def _process_limits(*symbols):
     limits = []
     orientation = 1
     for V in symbols:
-        if isinstance(V, Symbol):
+        if isinstance(V, (Dummy, Symbol)):
             limits.append(Tuple(V))
             continue
         elif is_sequence(V, Tuple):

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -519,7 +519,7 @@ class Basic(metaclass=ManagedProperties):
 
     @staticmethod
     def _recursive_call(expr_to_call, on_args):
-        from sympy import Symbol
+        from sympy.core.symbol import Dummy, Symbol
 
         def the_call_method_is_overridden(expr):
             for cls in getmro(type(expr)):
@@ -527,8 +527,8 @@ class Basic(metaclass=ManagedProperties):
                     return cls != Basic
 
         if callable(expr_to_call) and the_call_method_is_overridden(expr_to_call):
-            if isinstance(expr_to_call, Symbol):  # XXX When you call a Symbol it is
-                return expr_to_call               # transformed into an UndefFunction
+            if isinstance(expr_to_call, (Dummy, Symbol)):  # XXX When you call a Symbol it is
+                return expr_to_call                        # transformed into an UndefFunction
             else:
                 return expr_to_call(*on_args)
         elif expr_to_call.args:

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1016,7 +1016,7 @@ class Expr(Basic, EvalfMixin):
                     if oi.is_Symbol:
                         return S.One
                     if oi.is_Pow:
-                        syms = oi.atoms(Symbol)
+                        syms = oi.atoms(Dummy, Symbol)
                         if len(syms) == 1:
                             x = syms.pop()
                             oi = oi.subs(x, Dummy('x', positive=True))
@@ -1582,7 +1582,7 @@ class Expr(Basic, EvalfMixin):
         as_coeff_add
         as_coeff_mul
         """
-        from sympy import Symbol
+        from sympy.core.symbol import Dummy, Symbol
         from sympy.utilities.iterables import sift
 
         func = self.func
@@ -1591,7 +1591,7 @@ class Expr(Basic, EvalfMixin):
         sym = set()
         other = []
         for d in deps:
-            if isinstance(d, Symbol):  # Symbol.is_Symbol is True
+            if isinstance(d, (Dummy, Symbol)):  # Symbol.is_Symbol is True
                 sym.add(d)
             else:
                 other.append(d)
@@ -2439,10 +2439,10 @@ class Expr(Basic, EvalfMixin):
         >>> abs(x).series(dir="-")
         -x
         """
-        from sympy import collect, Dummy, Order, Rational, Symbol, ceiling
+        from sympy import collect, Dummy, Symbol, Order, Rational, ceiling
 
         if x is None:
-            syms = self.atoms(Symbol)
+            syms = self.atoms(Dummy, Symbol)
             if not syms:
                 return self
             elif len(syms) > 1:

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -5,7 +5,7 @@ from .compatibility import ordered
 from .expr import Expr
 from .evalf import EvalfMixin, DEFAULT_MAXPREC as target
 from .function import _coeff_isneg
-from .symbol import Symbol
+from .symbol import Dummy, Symbol
 from .sympify import _sympify
 from .evaluate import global_evaluate
 from sympy.logic.boolalg import Boolean
@@ -180,7 +180,7 @@ class Relational(Boolean, Expr, EvalfMixin):
                 # True/False answer.  Check if we can deduce that dif is
                 # definitively zero or non-zero.  If non-zero, replace with an
                 # approximation.  If .equals(0) gives None, cannot be deduced.
-                if not dif.has(Symbol):
+                if not dif.has(Dummy, Symbol):
                     know = dif.equals(0)
                     if know:
                         dif = S.Zero

--- a/sympy/core/symbol.py
+++ b/sympy/core/symbol.py
@@ -13,20 +13,10 @@ from sympy.logic.boolalg import Boolean
 from sympy.utilities.iterables import cartes
 
 
-class Symbol(AtomicExpr, Boolean):
-    """
-    Assumptions:
-       commutative = True
+class BaseSymbol(AtomicExpr, Boolean):
+    """Abstract class for Symbols.
 
-    You can override the default assumptions in the constructor:
-
-    >>> from sympy import symbols
-    >>> A,B = symbols('A,B', commutative = False)
-    >>> bool(A*B != B*A)
-    True
-    >>> bool(A*B*2 == 2*A*B) == True # multiplication by scalars is commutative
-    True
-
+    Do not instantiate this, use Symbol, Dummy or Wild.
     """
 
     is_comparable = False
@@ -80,7 +70,7 @@ class Symbol(AtomicExpr, Boolean):
 
         """
         cls._sanitize(assumptions, cls)
-        return Symbol.__xnew_cached_(cls, name, **assumptions)
+        return BaseSymbol.__xnew_cached_(cls, name, **assumptions)
 
     def __new_stage2__(cls, name, **assumptions):
         if not isinstance(name, str):
@@ -159,7 +149,45 @@ class Symbol(AtomicExpr, Boolean):
         return {self}
 
 
-class Dummy(Symbol):
+class Symbol(BaseSymbol):
+    """Symbol is a placeholder for atomic symbolic expression.
+
+    It has a name and a set of assumptions.
+
+    Parameters
+    ==========
+
+    name : str
+        The name for Symbol.
+    \*\*assumptions : dict
+        Keyword arguments to specify assumptions for
+        Symbol.  Default assumption is commutative=True.
+
+    Examples
+    ========
+
+    >>> from sympy import symbols
+    >>> a, b = symbols('a,b')
+    >>> bool(a*b == b*a)
+    True
+
+    You can override default assumptions:
+
+    >>> A, B = symbols('A,B', commutative = False)
+    >>> bool(A*B != B*A)
+    True
+    >>> bool(A*B*2 == 2*A*B) == True # multiplication by scalars is commutative
+    True
+
+    See Also
+    ========
+
+    :mod:`sympy.core.assumptions`
+    """
+    pass
+
+
+class Dummy(BaseSymbol):
     """Dummy symbols are each unique, identified by an internal count index:
 
     >>> from sympy import Dummy
@@ -173,6 +201,10 @@ class Dummy(Symbol):
     >>> Dummy() #doctest: +SKIP
     _Dummy_10
 
+    See Also
+    ========
+
+    Symbol
     """
 
     _count = 0
@@ -205,13 +237,11 @@ class Dummy(Symbol):
             2, (str(self), self.dummy_index)), S.One.sort_key(), S.One
 
     def _hashable_content(self):
-        return Symbol._hashable_content(self) + (self.dummy_index,)
+        return BaseSymbol._hashable_content(self) + (self.dummy_index,)
 
 
-class Wild(Symbol):
-    """
-    A Wild symbol matches anything, or anything
-    without whatever is explicitly excluded.
+class Wild(BaseSymbol):
+    """A Wild symbol matches anything, whatever is not explicitly excluded.
 
     Examples
     ========
@@ -235,8 +265,8 @@ class Wild(Symbol):
     >>> A.match(a)
     {a_: A_}
 
-    Tips
-    ====
+    Notes
+    =====
 
     When using Wild, be sure to use the exclude
     keyword to make the pattern more precise.
@@ -275,6 +305,10 @@ class Wild(Symbol):
     >>> E.match(a*b) == {a: 2, b: x**3*y*z}
     True
 
+    See Also
+    ========
+
+    Symbol
     """
     is_Wild = True
 
@@ -292,7 +326,7 @@ class Wild(Symbol):
     @staticmethod
     @cacheit
     def __xnew__(cls, name, exclude, properties, **assumptions):
-        obj = Symbol.__xnew__(cls, name, **assumptions)
+        obj = BaseSymbol.__xnew__(cls, name, **assumptions)
         obj.exclude = exclude
         obj.properties = properties
         return obj

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -894,6 +894,11 @@ def test_sympy__stats__drv_types__GeometricDistribution():
     assert _test_args(GeometricDistribution(.5))
 
 
+@SKIP("abstract class")
+def test_sympy__core__symbol__BaseSymbol():
+    pass
+
+
 def test_sympy__core__symbol__Dummy():
     from sympy.core.symbol import Dummy
     assert _test_args(Dummy('t'))

--- a/sympy/core/tests/test_args.py
+++ b/sympy/core/tests/test_args.py
@@ -894,7 +894,6 @@ def test_sympy__stats__drv_types__GeometricDistribution():
     assert _test_args(GeometricDistribution(.5))
 
 
-@SKIP("abstract class")
 def test_sympy__core__symbol__BaseSymbol():
     pass
 

--- a/sympy/core/tests/test_relational.py
+++ b/sympy/core/tests/test_relational.py
@@ -2,7 +2,7 @@ import pytest
 
 from sympy import (S, Symbol, symbols, nan, oo, I, pi, Float, And, Or, Not,
                    Implies, Xor, zoo, sqrt, Rational, simplify, Function,
-                   Integer)
+                   Wild, Integer)
 from sympy.core.relational import (Relational, Equality, Unequality,
                                    GreaterThan, LessThan, StrictGreaterThan,
                                    StrictLessThan, Rel, Eq, Lt, Le,
@@ -656,3 +656,9 @@ def test_issue_8444():
     i = symbols('i', integer=True)
     assert (i > floor(i)) == False
     assert (i < ceiling(i)) == False
+
+
+def test_issue_7951():
+    p = Wild('p')
+    x = Symbol('x')
+    assert str(x < p) == 'x < p_'

--- a/sympy/functions/elementary/complexes.py
+++ b/sympy/functions/elementary/complexes.py
@@ -922,7 +922,7 @@ class principal_branch(Function):
 
     @classmethod
     def eval(self, x, period):
-        from sympy import oo, exp_polar, I, Mul, polar_lift, Symbol
+        from sympy import oo, exp_polar, I, Mul, polar_lift
         if isinstance(x, polar_lift):
             return principal_branch(x.args[0], period)
         if period == oo:
@@ -982,7 +982,7 @@ def _polarify(eq, lift, pause=False):
         return eq
     if eq.is_number and not pause:
         return polar_lift(eq)
-    if isinstance(eq, Symbol) and not pause and lift:
+    if isinstance(eq, (Dummy, Symbol)) and not pause and lift:
         return polar_lift(eq)
     elif eq.is_Atom:
         return eq

--- a/sympy/functions/elementary/integers.py
+++ b/sympy/functions/elementary/integers.py
@@ -4,7 +4,7 @@ from sympy.core import Add
 from sympy.core.evalf import PrecisionExhausted
 from sympy.core.numbers import Integer
 from sympy.core.relational import Gt, Lt, Ge, Le
-from sympy.core.symbol import Symbol
+from sympy.core.symbol import Dummy, Symbol
 
 
 ###############################################################################
@@ -39,7 +39,7 @@ class RoundFunction(Function):
         for t in terms:
             if t.is_integer or (t.is_imaginary and im(t).is_integer):
                 ipart += t
-            elif t.has(Symbol):
+            elif t.has(Dummy, Symbol):
                 spart += t
             else:
                 npart += t

--- a/sympy/geometry/util.py
+++ b/sympy/geometry/util.py
@@ -10,7 +10,7 @@ are_coplanar
 are_similar
 """
 
-from sympy import Symbol, Function, solve
+from sympy import Dummy, Symbol, Function, solve
 from sympy.core.compatibility import is_sequence
 
 
@@ -57,7 +57,7 @@ def idiff(eq, y, x, n=1):
     if is_sequence(y):
         dep = set(y)
         y = y[0]
-    elif isinstance(y, Symbol):
+    elif isinstance(y, (Dummy, Symbol)):
         dep = {y}
     else:
         raise ValueError("expecting x-dependent symbol(s) but got: %s" % y)
@@ -110,7 +110,7 @@ def _symbol(s, matching_symbol=None):
         if matching_symbol and matching_symbol.name == s:
             return matching_symbol
         return Symbol(s, extended_real=True)
-    elif isinstance(s, Symbol):
+    elif isinstance(s, (Dummy, Symbol)):
         return s
     else:
         raise ValueError('symbol must be string for symbol name or Symbol')

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -276,7 +276,7 @@ class Integral(AddWithLimits):
                 Expecting a tuple (expr, symbol) where symbol identified
                 a free symbol in expr, but symbol is not in expr's free
                 symbols.'''))
-            if not isinstance(uvar, Symbol):
+            if not isinstance(uvar, (Dummy, Symbol)):
                 raise ValueError(filldedent('''
                 Expecting a tuple (expr, symbol) but didn't get
                 a symbol; got %s''' % uvar))

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -240,11 +240,11 @@ def power_rule(integral):
     integrand, symbol = integral
     base, exp = integrand.as_base_exp()
 
-    if symbol not in exp.free_symbols and isinstance(base, sympy.Symbol):
+    if symbol not in exp.free_symbols and isinstance(base, (sympy.Dummy, sympy.Symbol)):
         if sympy.simplify(exp + 1) == 0:
             return ReciprocalRule(base, integrand, symbol)
         return PowerRule(base, exp, integrand, symbol)
-    elif symbol not in base.free_symbols and isinstance(exp, sympy.Symbol):
+    elif symbol not in base.free_symbols and isinstance(exp, (sympy.Dummy, sympy.Symbol)):
         rule = ExpRule(base, exp, integrand, symbol)
 
         if sympy.log(base).is_nonzero:
@@ -260,7 +260,7 @@ def power_rule(integral):
 
 def exp_rule(integral):
     integrand, symbol = integral
-    if isinstance(integrand.args[0], sympy.Symbol):
+    if isinstance(integrand.args[0], (sympy.Dummy, sympy.Symbol)):
         return ExpRule(sympy.E, integrand.args[0], integrand, symbol)
 
 
@@ -479,7 +479,7 @@ def trig_rule(integral):
     if isinstance(integrand, sympy.sin) or isinstance(integrand, sympy.cos):
         arg = integrand.args[0]
 
-        if not isinstance(arg, sympy.Symbol):
+        if not isinstance(arg, (sympy.Dummy, sympy.Symbol)):
             return  # perhaps a substitution can deal with it
 
         if isinstance(integrand, sympy.sin):
@@ -929,7 +929,7 @@ def integral_steps(integrand, symbol, **options):
         elif symbol not in integrand.free_symbols:
             return sympy.Number
         else:
-            for cls in (sympy.Pow, sympy.Symbol, sympy.log,
+            for cls in (sympy.Pow, sympy.Dummy, sympy.Symbol, sympy.log,
                         sympy.Add, sympy.Mul, sympy.atan, sympy.asin, sympy.acos, sympy.Heaviside):
                 if isinstance(integrand, cls):
                     return cls
@@ -943,6 +943,7 @@ def integral_steps(integrand, symbol, **options):
     result = do_one([
         null_safe(switch(key, {
             sympy.Pow: do_one([null_safe(power_rule), null_safe(inverse_trig_rule)]),
+            sympy.Dummy: power_rule,
             sympy.Symbol: power_rule,
             sympy.Add: add_rule,
             sympy.Mul: do_one([null_safe(mul_rule), null_safe(trig_product_rule),

--- a/sympy/integrals/rationaltools.py
+++ b/sympy/integrals/rationaltools.py
@@ -1,6 +1,6 @@
 """This module implements tools for integrating rational functions. """
 
-from sympy import (Symbol, symbols, I, log, atan, roots, RootSum,
+from sympy import (S, Symbol, symbols, I, log, atan, roots, RootSum,
                    Lambda, cancel, Dummy, Integer, Rational)
 from sympy.polys import Poly, resultant, ZZ
 from sympy.polys.polytools import count_roots

--- a/sympy/matrices/tests/test_matrices.py
+++ b/sympy/matrices/tests/test_matrices.py
@@ -3,7 +3,7 @@ import collections
 import pytest
 
 from sympy import (Abs, E, Float, I, Integer, Max, Min, N, Poly, Pow,
-                   PurePoly, Rational, S, Symbol, cos, exp, oo, pi,
+                   PurePoly, Rational, S, Dummy, Symbol, cos, exp, oo, pi,
                    signsimp, simplify, sin, sqrt, symbols, sympify,
                    trigsimp, sstr)
 from sympy.matrices.matrices import (ShapeError, MatrixError,
@@ -2379,7 +2379,7 @@ def test_pinv_solve():
     B = Matrix([5, 7])
     solution = A.pinv_solve(B)
     w = {}
-    for s in solution.atoms(Symbol):
+    for s in solution.atoms(Dummy, Symbol):
         # Extract dummy symbols used in the solution.
         w[s.name] = s
     assert solution == Matrix([[w['w0_0']/3 + w['w1_0']/3 - w['w2_0']/3 + 1],

--- a/sympy/parsing/sympy_parser.py
+++ b/sympy/parsing/sympy_parser.py
@@ -9,6 +9,7 @@ from tokenize import (tokenize, untokenize, TokenError,
 from keyword import iskeyword
 
 import sympy
+from sympy.core.symbol import Symbol
 from sympy.core.basic import Basic
 
 
@@ -42,7 +43,7 @@ def _token_callable(token, local_dict, global_dict, nextToken=None):
     func = local_dict.get(token[1])
     if not func:
         func = global_dict.get(token[1])
-    return callable(func) and not isinstance(func, sympy.Symbol)
+    return callable(func) and not isinstance(func, Symbol)
 
 
 class AppliedFunction(object):

--- a/sympy/plotting/experimental_lambdify.py
+++ b/sympy/plotting/experimental_lambdify.py
@@ -14,7 +14,7 @@ import re
 import warnings
 
 from sympy.external import import_module
-from sympy import Symbol, NumberSymbol, I, zoo, oo
+from sympy import Dummy, Symbol, NumberSymbol, I, zoo, oo
 from sympy.utilities.iterables import numbered_symbols
 
 #  We parse the expression string into a tree that identifies functions. Then
@@ -254,7 +254,7 @@ class Lambdifier(object):
 
         # Constructing the argument string
         # - check
-        if not all([isinstance(a, Symbol) for a in args]):
+        if not all([isinstance(a, (Dummy, Symbol)) for a in args]):
             raise ValueError('The arguments must be Symbols.')
         # - use numbered symbols
         syms = numbered_symbols(exclude=expr.free_symbols)
@@ -630,7 +630,7 @@ class Lambdifier(object):
             # XXX debug: print funcname
             args_dict = {}
             for a in expr.args:
-                if (isinstance(a, Symbol) or
+                if (isinstance(a, (Dummy, Symbol)) or
                     isinstance(a, NumberSymbol) or
                         a in [I, zoo, oo]):
                     continue
@@ -643,7 +643,7 @@ class Lambdifier(object):
     def sympy_atoms_namespace(expr):
         """For no real reason this function is separated from
         sympy_expression_namespace. It can be moved to it."""
-        atoms = expr.atoms(Symbol, NumberSymbol, I, zoo, oo)
+        atoms = expr.atoms(Dummy, Symbol, NumberSymbol, I, zoo, oo)
         d = {}
         for a in atoms:
             # XXX debug: print 'atom:' + str(a)

--- a/sympy/plotting/plot_implicit.py
+++ b/sympy/plotting/plot_implicit.py
@@ -341,7 +341,7 @@ def plot_implicit(expr, x_var=None, y_var=None, **kwargs):
     default_range = Tuple(-5, 5)
 
     def _range_tuple(s):
-        if isinstance(s, Symbol):
+        if isinstance(s, (Dummy, Symbol)):
             return Tuple(s) + default_range
         if len(s) == 3:
             return Tuple(*s)

--- a/sympy/polys/orderings.py
+++ b/sympy/polys/orderings.py
@@ -2,7 +2,7 @@
 
 __all__ = ["lex", "grlex", "grevlex", "ilex", "igrlex", "igrevlex"]
 
-from sympy.core import Symbol
+from sympy.core.symbol import Symbol
 from sympy.core.compatibility import iterable
 
 

--- a/sympy/printing/latex.py
+++ b/sympy/printing/latex.py
@@ -1229,7 +1229,7 @@ class LatexPrinter(Printer):
 
         return self._deal_with_super_sub(expr.name) if \
             '\\' not in expr.name else expr.name
-
+    _print_Wild = _print_Symbol
     _print_RandomSymbol = _print_Symbol
     _print_MatrixSymbol = _print_Symbol
 

--- a/sympy/printing/pretty/pretty.py
+++ b/sympy/printing/pretty/pretty.py
@@ -61,6 +61,7 @@ class PrettyPrinter(Printer):
     def _print_Symbol(self, e):
         symb = pretty_symbol(e.name)
         return prettyForm(symb)
+    _print_Dummy = _print_Symbol
     _print_RandomSymbol = _print_Symbol
 
     def _print_Float(self, e):

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -149,6 +149,8 @@ class ReprPrinter(Printer):
             attr = ['%s=%s' % (k, v) for k, v in d.items()]
             return "%s(%s, %s)" % (expr.__class__.__name__,
                                    self._print(expr.name), ', '.join(attr))
+    _print_Dummy = _print_Symbol
+    _print_Wild = _print_Symbol
 
     def _print_Predicate(self, expr):
         return "%s(%s)" % (expr.__class__.__name__, self._print(expr.name))

--- a/sympy/series/order.py
+++ b/sympy/series/order.py
@@ -116,7 +116,7 @@ class Order(Expr):
                 variables = list(map(sympify, args))
                 point = [S.Zero]*len(variables)
 
-        if not all(isinstance(v, Symbol) for v in variables):
+        if not all(isinstance(v, (Dummy, Symbol)) for v in variables):
             raise TypeError('Variables are not symbols, got %s' % variables)
 
         if len(list(uniq(variables))) != len(variables):

--- a/sympy/solvers/inequalities.py
+++ b/sympy/solvers/inequalities.py
@@ -484,7 +484,7 @@ def _reduce_inequalities(inequalities, symbols):
         # check for gens using atoms which is more strict than free_symbols to
         # guard against EX domain which won't be handled by
         # reduce_rational_inequalities
-        gens = expr.atoms(Symbol)
+        gens = expr.atoms(Dummy, Symbol)
 
         if len(gens) == 1:
             gen = gens.pop()

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -783,7 +783,7 @@ def solve(f, *symbols, **flags):
     bare_f = not iterable(f)
     ordered_symbols = (symbols and
                        symbols[0] and
-                       (isinstance(symbols[0], Symbol) or
+                       (isinstance(symbols[0], (Dummy, Symbol)) or
                         is_sequence(symbols[0],
                         include=GeneratorType)
                        )

--- a/sympy/solvers/tests/test_inequalities.py
+++ b/sympy/solvers/tests/test_inequalities.py
@@ -235,7 +235,7 @@ def test_issue_10203():
     y = Symbol('y', extended_real=True)
     assert reduce_inequalities(Eq(0, x - y), symbols=[x]) == Eq(x, y)
     assert reduce_inequalities(Ne(0, x - y), symbols=[x]) == \
-        Or(And(-oo < x, x < y), And(x < oo, x > y))
+        Or(And(-oo < x, x < y), And(x < oo, y < x))
 
 
 def test_issue_6343():

--- a/sympy/tensor/indexed.py
+++ b/sympy/tensor/indexed.py
@@ -105,7 +105,7 @@
 #      - Idx with stepsize != 1
 #      - Idx with step determined by function call
 
-from sympy.core import Expr, Tuple, Symbol, sympify, S
+from sympy.core import Expr, Tuple, Dummy, Symbol, sympify, S
 from sympy.core.compatibility import is_sequence, NotIterable
 
 
@@ -325,7 +325,7 @@ class IndexedBase(Expr, NotIterable):
     def __new__(cls, label, shape=None, **kw_args):
         if isinstance(label, str):
             label = Symbol(label)
-        elif isinstance(label, Symbol):
+        elif isinstance(label, (Dummy, Symbol)):
             pass
         else:
             raise TypeError("Base label should be a string or Symbol.")

--- a/sympy/utilities/autowrap.py
+++ b/sympy/utilities/autowrap.py
@@ -357,7 +357,7 @@ class CythonCodeWrapper(CodeWrapper):
         # locally in the Cython code.
             if isinstance(arg, (InputArgument, InOutArgument)) and arg.dimensions:
                 dims = [d[1] + 1 for d in arg.dimensions]
-                sym_dims = [(i, d) for (i, d) in enumerate(dims) if isinstance(d, Symbol)]
+                sym_dims = [(i, d) for (i, d) in enumerate(dims) if isinstance(d, (Dummy, Symbol))]
                 for (i, d) in sym_dims:
                     py_inferred[d] = (arg.name, i)
         for arg in args:
@@ -863,7 +863,7 @@ def ufuncify(args, expr, language=None, backend='numpy', tempdir=None,
     array([ 3.])
     """
 
-    if isinstance(args, Symbol):
+    if isinstance(args, (Dummy, Symbol)):
         args = (args,)
     else:
         args = tuple(args)

--- a/sympy/utilities/codegen.py
+++ b/sympy/utilities/codegen.py
@@ -81,7 +81,7 @@ import os
 import textwrap
 
 from sympy import __version__ as sympy_version
-from sympy.core import Symbol, S, Expr, Tuple, Equality, Function
+from sympy.core import Dummy, Symbol, S, Expr, Tuple, Equality, Function
 from sympy.core.compatibility import is_sequence
 from sympy.printing.codeprinter import AssignmentError
 from sympy.printing.ccode import ccode, CCodePrinter
@@ -263,7 +263,7 @@ class Variable(object):
             Controls the precision of floating point constants.
 
         """
-        if not isinstance(name, (Symbol, MatrixSymbol)):
+        if not isinstance(name, (Dummy, Symbol, MatrixSymbol)):
             raise TypeError("The first argument must be a sympy symbol.")
         if datatype is None:
             datatype = get_default_datatype(name)


### PR DESCRIPTION
see https://github.com/sympy/sympy/issues/7951 and https://bugs.python.org/issue22052

- [x] verbose commit messages
- [ ] better docstring for BaseSymbol (i.e. document why we need this)
