### PR TITLE
Use srepr instead of sstr for __repr__ printing

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -43,3 +43,16 @@ def check_disabled(request):
         if (V(pytest.__version__) < '2.6.3' and
                 pytest.config.getvalue('-s') != 'no'):
             pytest.skip("run py.test with -s or upgrade to newer version.")
+
+
+@pytest.fixture(autouse=True, scope='session')
+def set_displayhook():
+    import sys
+    from sympy import init_printing
+
+    # hook our nice, hash-stable strprinter
+    init_printing(pretty_print=False, use_unicode=False)
+
+    # doctest restore sys.displayhook from __displayhook__,
+    # see https://bugs.python.org/issue26092.
+    sys.__displayhook__ = sys.displayhook

--- a/docs/modules/logic.rst
+++ b/docs/modules/logic.rst
@@ -36,7 +36,7 @@ Like most types in SymPy, Boolean expressions inherit from
 :class:`~sympy.core.basic.Basic`::
 
     >>> (y & x).subs({x: True, y: True})
-    True
+    true
     >>> (x | y).atoms() == {x, y}
     True
 

--- a/docs/tutorial/gotchas.rst
+++ b/docs/tutorial/gotchas.rst
@@ -449,7 +449,7 @@ unsimplified trig identity, multiplied by a big number:
     >>> big = 12345678901234567890
     >>> big_trig_identity = big*cos(x)**2 + big*sin(x)**2 - big*1
     >>> abs(big_trig_identity.subs(x, .1).n(2)) > 1000
-    True
+    true
 
 When the `\cos` and `\sin` terms were evaluated to 15 digits of precision and
 multiplied by the big number, they gave a large number that was only

--- a/docs/tutorial/gotchas.rst
+++ b/docs/tutorial/gotchas.rst
@@ -329,7 +329,7 @@ you don't have to worry about this problem:
     Rational.
 
     >>> x = Symbol('x')
-    >>> print(solve(7*x - 22, x))
+    >>> solve(7*x - 22, x)
     [22/7]
     >>> 22/7  # After copy and paste we get a float
     3.142857142857143

--- a/docs/tutorial/manipulation.rst
+++ b/docs/tutorial/manipulation.rst
@@ -13,19 +13,19 @@ Understanding Expression Trees
 Before we can do this, we need to understand how expressions are represented
 in SymPy.  A mathematical expression is represented as a tree.  Let us take
 the expression `x^2 + xy`, i.e., ``x**2 + x*y``.  We can see what this
-expression looks like internally by using ``srepr``
+expression looks like internally by using ``repr``
 
     >>> from sympy import *
     >>> x, y, z = symbols('x y z')
 
     >>> expr = x**2 + x*y
-    >>> srepr(expr)
+    >>> repr(expr)
     "Add(Pow(Symbol('x'), Integer(2)), Mul(Symbol('x'), Symbol('y')))"
 
 The easiest way to tear this apart is to look at a diagram of the expression
 tree:
 
-.. This comes from dotprint(x**2 + x*y, labelfunc=srepr)
+.. This comes from dotprint(x**2 + x*y, labelfunc=repr)
 
 .. graphviz::
 
@@ -81,7 +81,7 @@ integers.  It is similar to the Python built-in type ``int``, except that
 When we write ``x**2``, this creates a ``Pow`` object.  ``Pow`` is short for
 "power".
 
-    >>> srepr(x**2)
+    >>> repr(x**2)
     "Pow(Symbol('x'), Integer(2))"
 
 We could have created the same object by calling ``Pow(x, 2)``
@@ -89,7 +89,7 @@ We could have created the same object by calling ``Pow(x, 2)``
     >>> Pow(x, 2)
     x**2
 
-Note that in the ``srepr`` output, we see ``Integer(2)``, the SymPy version of
+Note that in the ``repr`` output, we see ``Integer(2)``, the SymPy version of
 integers, even though technically, we input ``2``, a Python int.  In general,
 whenever you combine a SymPy object with a non-SymPy object via some function
 or operation, the non-SymPy object will be converted into a SymPy object.  The
@@ -104,7 +104,7 @@ We have seen that ``x**2`` is represented as ``Pow(x, 2)``.  What about
 ``x*y``?  As we might expect, this is the multiplication of ``x`` and ``y``.
 The SymPy class for multiplication is ``Mul``.
 
-    >>> srepr(x*y)
+    >>> repr(x*y)
     "Mul(Symbol('x'), Symbol('y'))"
 
 Thus, we could have created the same object by writing ``Mul(x, y)``.
@@ -124,13 +124,13 @@ SymPy expression trees can have many branches, and can be quite deep or quite
 broad.  Here is a more complicated example
 
     >>> expr = sin(x*y)/2 - x**2 + 1/y
-    >>> srepr(expr)
+    >>> repr(expr)
     "Add(Mul(Integer(-1), Pow(Symbol('x'), Integer(2))), Mul(Rational(1, 2),
     sin(Mul(Symbol('x'), Symbol('y')))), Pow(Symbol('y'), Integer(-1)))"
 
 Here is a diagram
 
-.. dotprint(sin(x*y)/2 - x**2 + 1/y, labelfunc=srepr)
+.. dotprint(sin(x*y)/2 - x**2 + 1/y, labelfunc=repr)
 
 .. graphviz::
 
@@ -189,10 +189,10 @@ class in SymPy.  ``x - y`` is represented as ``x + -y``, or, more completely,
 ``x + -1*y``, i.e., ``Add(x, Mul(-1, y))``.
 
     >>> expr = x - y
-    >>> srepr(x - y)
+    >>> repr(x - y)
     "Add(Symbol('x'), Mul(Integer(-1), Symbol('y')))"
 
-.. dotprint(x - y, labelfunc=srepr)
+.. dotprint(x - y, labelfunc=repr)
 
 .. graphviz::
 
@@ -229,10 +229,10 @@ What if we had divided something other than 1 by ``y``, like ``x/y``?  Let's
 see.
 
     >>> expr = x/y
-    >>> srepr(expr)
+    >>> repr(expr)
     "Mul(Symbol('x'), Pow(Symbol('y'), Integer(-1)))"
 
-.. dotprint(x/y, labelfunc=srepr)
+.. dotprint(x/y, labelfunc=repr)
 
 .. graphviz::
 
@@ -272,7 +272,7 @@ numbers are always combined into a single term in a multiplication, so that
 when we divide by 2, it is represented as multiplying by 1/2.
 
 Finally, one last note.  You may have noticed that the order we entered our
-expression and the order that it came out from ``srepr`` or in the graph were
+expression and the order that it came out from ``repr`` or in the graph were
 different.  You may have also noticed this phenonemon earlier in the
 tutorial.  For example
 
@@ -381,7 +381,7 @@ Mul's ``args`` are sorted, so that the same ``Mul`` will have the same
 ``args``.  But the sorting is based on some criteria designed to make the
 sorting unique and efficient that has no mathematical significance.
 
-The ``srepr`` form of our ``expr`` is ``Mul(3, x, Pow(y, 2))``.  What if we
+The ``repr`` form of our ``expr`` is ``Mul(3, x, Pow(y, 2))``.  What if we
 want to get at the ``args`` of ``Pow(y, 2)``.  Notice that the ``y**2`` is in
 the third slot of ``expr.args``, i.e., ``expr.args[2]``.
 

--- a/docs/tutorial/printing.rst
+++ b/docs/tutorial/printing.rst
@@ -73,9 +73,9 @@ repr
 
 The repr form of an expression is designed to show the exact form of an
 expression.  It will be discussed more in the :ref:`tutorial-manipulation`
-section.  To get it, use ``srepr()`` [#srepr-fn]_.
+section.  To get it, use ``repr()``.
 
-    >>> srepr(Integral(sqrt(1/x), x))
+    >>> repr(Integral(sqrt(1/x), x))
     "Integral(Pow(Pow(Symbol('x'), Integer(-1)), Rational(1, 2)), Tuple(Symbol('x')))"
 
 The repr form is mostly useful for understanding how an expression is built
@@ -177,11 +177,3 @@ The ``dotprint()`` function in ``sympy.printing.dot`` prints output to dot
 format, which can be rendered with Graphviz.  See the
 :ref:`tutorial-manipulation` section for some examples of the output of this
 printer.
-
-.. rubric:: Footnotes
-
-.. [#srepr-fn] SymPy does not use the Python builtin ``repr()`` function for
-   repr printing, because in Python ``str(list)`` calls ``repr()`` on the
-   elements of the list, and some SymPy functions return lists (such as
-   ``solve()``).  Since ``srepr()`` is so verbose, it is unlikely that anyone
-   would want it called by default on the output of ``solve()``.

--- a/sympy/calculus/finite_diff.py
+++ b/sympy/calculus/finite_diff.py
@@ -129,7 +129,7 @@ def finite_diff_weights(order, x_list, x0=Integer(0)):
     >>> from sympy.calculus import finite_diff_weights
     >>> N, (h, x) = 4, symbols('h x')
     >>> x_list = [x+h*cos(i*pi/(N)) for i in range(N,-1,-1)] # chebyshev nodes
-    >>> print(x_list)
+    >>> x_list
     [-h + x, -sqrt(2)*h/2 + x, x, sqrt(2)*h/2 + x, h + x]
     >>> mycoeffs = finite_diff_weights(1, x_list, 0)[1][4]
     >>> [simplify(c) for c in  mycoeffs] #doctest: +NORMALIZE_WHITESPACE

--- a/sympy/categories/diagram_drawing.py
+++ b/sympy/categories/diagram_drawing.py
@@ -1347,9 +1347,8 @@ class DiagramGrid(object):
         >>> g = NamedMorphism(B, C, "g")
         >>> diagram = Diagram([f, g])
         >>> grid = DiagramGrid(diagram)
-        >>> print(grid)
-        [[Object("A"), Object("B")],
-        [None, Object("C")]]
+        >>> grid
+        [[Object('A'), Object('B')], [None, Object('C')]]
 
         """
         return repr(self._grid._array)

--- a/sympy/categories/tests/test_drawing.py
+++ b/sympy/categories/tests/test_drawing.py
@@ -136,8 +136,7 @@ def test_DiagramGrid():
     assert grid.morphisms == {f: FiniteSet(), g: FiniteSet(), h: FiniteSet(),
                               k: FiniteSet()}
 
-    assert str(grid) == '[[Object("A"), Object("B"), Object("D")], ' \
-        '[None, Object("C"), None]]'
+    assert str(grid) == "[[Object('A'), Object('B'), Object('D')], [None, Object('C'), None]]"
 
     # A chain of morphisms.
     f = NamedMorphism(A, B, "f")

--- a/sympy/combinatorics/partitions.py
+++ b/sympy/combinatorics/partitions.py
@@ -163,7 +163,7 @@ class Partition(FiniteSet):
         >>> a <= a
         True
         >>> a <= b
-        True
+        true
         """
         return self.sort_key() <= sympify(other).sort_key()
 
@@ -180,7 +180,7 @@ class Partition(FiniteSet):
         >>> a.rank, b.rank
         (9, 34)
         >>> a < b
-        True
+        true
         """
         return self.sort_key() < sympify(other).sort_key()
 

--- a/sympy/combinatorics/polyhedron.py
+++ b/sympy/combinatorics/polyhedron.py
@@ -256,13 +256,13 @@ class Polyhedron(Basic):
         represent it in a way that helps to visualize the Rubik's cube.
 
         >>> from sympy.utilities.iterables import flatten, unflatten
-        >>> from sympy import symbols
+        >>> from sympy import symbols, sstr
         >>> from sympy.combinatorics import RubikGroup
         >>> facelets = flatten([symbols(s+'1:5') for s in 'UFRBLD'])
         >>> def show():
         ...     pairs = unflatten(r2.corners, 2)
-        ...     print(pairs[::2])
-        ...     print(pairs[1::2])
+        ...     print(sstr(pairs[::2]))
+        ...     print(sstr(pairs[1::2]))
         ...
         >>> r2 = Polyhedron(facelets, pgroup=RubikGroup(2))
         >>> show()

--- a/sympy/concrete/delta.py
+++ b/sympy/concrete/delta.py
@@ -264,9 +264,9 @@ def deltasummation(f, limit, no_piecewise=False):
     >>> deltasummation(KroneckerDelta(i, k), (k, -oo, oo))
     1
     >>> deltasummation(KroneckerDelta(i, k), (k, 0, oo))
-    Piecewise((1, 0 <= i), (0, True))
+    Piecewise((1, 0 <= i), (0, true))
     >>> deltasummation(KroneckerDelta(i, k), (k, 1, 3))
-    Piecewise((1, And(1 <= i, i <= 3)), (0, True))
+    Piecewise((1, And(1 <= i, i <= 3)), (0, true))
     >>> deltasummation(k*KroneckerDelta(i, j)*KroneckerDelta(j, k), (k, -oo, oo))
     j*KroneckerDelta(i, j)
     >>> deltasummation(j*KroneckerDelta(i, j), (j, -oo, oo))

--- a/sympy/concrete/summations.py
+++ b/sympy/concrete/summations.py
@@ -79,7 +79,7 @@ class Sum(AddWithLimits,ExprWithIntLimits):
     >>> Sum(x**k, (k, 0, oo))
     Sum(x**k, (k, 0, oo))
     >>> Sum(x**k, (k, 0, oo)).doit()
-    Piecewise((1/(-x + 1), Abs(x) < 1), (Sum(x**k, (k, 0, oo)), True))
+    Piecewise((1/(-x + 1), Abs(x) < 1), (Sum(x**k, (k, 0, oo)), true))
     >>> Sum(x**k/factorial(k), (k, 0, oo)).doit()
     E**x
 

--- a/sympy/core/basic.py
+++ b/sympy/core/basic.py
@@ -363,8 +363,8 @@ class Basic(metaclass=ManagedProperties):
     # Note, we always use the default ordering (lex) in __str__ and __repr__,
     # regardless of the global setting.  See issue 5487.
     def __repr__(self):
-        from sympy.printing import sstr
-        return sstr(self, order=None)
+        from sympy.printing import srepr
+        return srepr(self, order=None)
 
     def __str__(self):
         from sympy.printing import sstr

--- a/sympy/core/expr.py
+++ b/sympy/core/expr.py
@@ -1047,7 +1047,7 @@ class Expr(Basic, EvalfMixin):
         >>> (-2*x*y).args_cnc()
         [[-1, 2, x, y], []]
         >>> (-2.5*x).args_cnc()
-        [[-1, 2.50000000000000, x], []]
+        [[-1, 2.5, x], []]
         >>> (-2*x*A*B*y).args_cnc()
         [[-1, 2, x, y], [A, B]]
         >>> (-2*x*A*B*y).args_cnc(split_1=False)

--- a/sympy/core/numbers.py
+++ b/sympy/core/numbers.py
@@ -2693,7 +2693,7 @@ class NaN(Number, metaclass=Singleton):
     >>> nan + 1
     nan
     >>> Eq(nan, nan)   # mathematical equality
-    False
+    false
     >>> nan == nan     # structural equality
     True
 
@@ -3099,7 +3099,7 @@ class Pi(NumberSymbol, metaclass=Singleton):
     >>> S.Pi
     pi
     >>> pi > 3
-    True
+    true
     >>> pi.is_irrational
     True
     >>> x = Symbol('x')
@@ -3160,7 +3160,7 @@ class GoldenRatio(NumberSymbol, metaclass=Singleton):
 
     >>> from sympy import S
     >>> S.GoldenRatio > 1
-    True
+    true
     >>> S.GoldenRatio.expand(func=True)
     1/2 + sqrt(5)/2
     >>> S.GoldenRatio.is_irrational
@@ -3223,9 +3223,9 @@ class EulerGamma(NumberSymbol, metaclass=Singleton):
     >>> from sympy import S
     >>> S.EulerGamma.is_irrational
     >>> S.EulerGamma > 0
-    True
+    true
     >>> S.EulerGamma > 1
-    False
+    false
 
     References
     ==========
@@ -3275,9 +3275,9 @@ class Catalan(NumberSymbol, metaclass=Singleton):
     >>> from sympy import S
     >>> S.Catalan.is_irrational
     >>> S.Catalan > 0
-    True
+    true
     >>> S.Catalan > 1
-    False
+    false
 
     References
     ==========

--- a/sympy/core/relational.py
+++ b/sympy/core/relational.py
@@ -261,15 +261,15 @@ class Equality(Relational):
     >>> Eq(y, x + x**2)
     Eq(y, x**2 + x)
     >>> Eq(2, 5)
-    False
+    false
     >>> Eq(2, 5, evaluate=False)
     Eq(2, 5)
     >>> _.doit()
-    False
+    false
     >>> Eq(exp(x), exp(x).rewrite(cos))
     Eq(E**x, sinh(x) + cosh(x))
     >>> simplify(_)
-    True
+    true
 
     See Also
     ========

--- a/sympy/core/tests/test_containers.py
+++ b/sympy/core/tests/test_containers.py
@@ -145,7 +145,7 @@ def test_Dict():
     assert set(d.items()) == {Tuple(x, Integer(1)), Tuple(y, Integer(2)), Tuple(z, Integer(3))}
     assert set(d) == {x, y, z}
     assert str(d) == '{x: 1, y: 2, z: 3}'
-    assert d.__repr__() == '{x: 1, y: 2, z: 3}'
+    assert d.__repr__() == "Dict(Tuple(Symbol('x'), Integer(1)), Tuple(Symbol('y'), Integer(2)), Tuple(Symbol('z'), Integer(3)))"
 
     # Test creating a Dict from a Dict.
     d = Dict({x: 1, y: 2, z: 3})

--- a/sympy/core/tests/test_symbol.py
+++ b/sympy/core/tests/test_symbol.py
@@ -2,7 +2,7 @@ import pytest
 
 from sympy import (Symbol, Wild, GreaterThan, LessThan, StrictGreaterThan,
                    StrictLessThan, pi, I, Rational, sympify, symbols, Dummy,
-                   Integer, Float)
+                   Integer, Float, sstr)
 
 
 def test_Symbol():
@@ -298,7 +298,7 @@ def test_symbols():
 
     # issue 6675
     def sym(s):
-        return str(symbols(s))
+        return sstr(symbols(s))
     assert sym('a0:4') == '(a0, a1, a2, a3)'
     assert sym('a2:4,b1:3') == '(a2, a3, b1, b2)'
     assert sym('a1(2:4)') == '(a12, a13)'

--- a/sympy/diffgeom/tests/test_diffgeom.py
+++ b/sympy/diffgeom/tests/test_diffgeom.py
@@ -12,6 +12,7 @@ from sympy.core import Symbol, symbols
 from sympy.simplify import trigsimp, simplify
 from sympy.functions import sqrt, atan2, sin
 from sympy.matrices import Matrix
+from sympy.printing import sstr
 
 TP = TensorProduct
 
@@ -108,12 +109,12 @@ def test_intcurve_diffequ():
     start_point = R2_r.point([1, 0])
     vector_field = -R2.y*R2.e_x + R2.x*R2.e_y
     equations, init_cond = intcurve_diffequ(vector_field, t, start_point)
-    assert str(equations) == '[f_1(t) + Derivative(f_0(t), t), -f_0(t) + Derivative(f_1(t), t)]'
-    assert str(init_cond) == '[f_0(0) - 1, f_1(0)]'
+    assert sstr(equations) == '[f_1(t) + Derivative(f_0(t), t), -f_0(t) + Derivative(f_1(t), t)]'
+    assert sstr(init_cond) == '[f_0(0) - 1, f_1(0)]'
     equations, init_cond = intcurve_diffequ(vector_field, t, start_point, R2_p)
-    assert str(
+    assert sstr(
         equations) == '[Derivative(f_0(t), t), Derivative(f_1(t), t) - 1]'
-    assert str(init_cond) == '[f_0(0) - 1, f_1(0)]'
+    assert sstr(init_cond) == '[f_0(0) - 1, f_1(0)]'
 
 
 def test_helpers_and_coordinate_dependent():

--- a/sympy/functions/combinatorial/factorials.py
+++ b/sympy/functions/combinatorial/factorials.py
@@ -593,7 +593,7 @@ class binomial(CombinatorialFunction):
     Rows of Pascal's triangle can be generated with the binomial function:
 
     >>> for N in range(8):
-    ...     print([ binomial(N, i) for i in range(N + 1)])
+    ...     [ binomial(N, i) for i in range(N + 1)]
     ...
     [1]
     [1, 1]

--- a/sympy/functions/combinatorial/tests/test_comb_numbers.py
+++ b/sympy/functions/combinatorial/tests/test_comb_numbers.py
@@ -4,7 +4,7 @@ import pytest
 
 from sympy import (Symbol, symbols, Dummy, S, Sum, Rational, oo, pi, I,
                    expand_func, diff, EulerGamma, cancel, re, im,
-                   Product, Integer)
+                   Product, Integer, sstr)
 from sympy.functions import (bernoulli, harmonic, bell, fibonacci, lucas, euler,
                              catalan, genocchi, binomial, gamma, sqrt, hyper, log,
                              digamma, trigamma, polygamma, factorial, sin,
@@ -317,7 +317,7 @@ def test_catalan():
     c = catalan(S.Half).evalf()
     assert str(c) == '0.848826363156775'
     c = catalan(I).evalf(3)
-    assert str((re(c), im(c))) == '(0.398, -0.0209)'
+    assert sstr((re(c), im(c))) == '(0.398, -0.0209)'
 
 
 def test_genocchi():

--- a/sympy/functions/elementary/miscellaneous.py
+++ b/sympy/functions/elementary/miscellaneous.py
@@ -73,7 +73,7 @@ def sqrt(arg):
 
     >>> from sympy import Eq
     >>> Eq(sqrt(x**2), x).subs(x, -1)
-    False
+    false
 
     This is because sqrt computes the principal square root, so the square may
     put the argument in a different branch.  This identity does hold if x is
@@ -142,7 +142,7 @@ def cbrt(arg):
 
     >>> from sympy import Eq
     >>> Eq(cbrt(x**3), x).subs(x, -1)
-    False
+    false
 
     This is because cbrt computes the principal cube root, this
     identity does hold if `x` is positive:

--- a/sympy/functions/special/bessel.py
+++ b/sympy/functions/special/bessel.py
@@ -699,7 +699,7 @@ def jn_zeros(n, k, method="sympy", dps=15):
 
     >>> from sympy import jn_zeros
     >>> jn_zeros(2, 4, dps=5)
-    [5.7635, 9.0950, 12.323, 15.515]
+    [5.7635, 9.095, 12.323, 15.515]
 
     See Also
     ========

--- a/sympy/functions/special/bsplines.py
+++ b/sympy/functions/special/bsplines.py
@@ -40,7 +40,7 @@ def bspline_basis(d, knots, n, x, close=True):
         >>> d = 0
         >>> knots = range(5)
         >>> bspline_basis(d, knots, 0, x)
-        Piecewise((1, And(x <= 1, x >= 0)), (0, True))
+        Piecewise((1, And(x <= 1, x >= 0)), (0, true))
 
     For a given ``(d, knots)`` there are ``len(knots)-d-1`` B-splines defined, that
     are indexed by ``n`` (starting at 0).
@@ -52,7 +52,7 @@ def bspline_basis(d, knots, n, x, close=True):
                   (-x**3/2 + 2*x**2 - 2*x + 2/3, And(x < 2, x >= 1)),
                   (x**3/2 - 4*x**2 + 10*x - 22/3, And(x < 3, x >= 2)),
                   (-x**3/6 + 2*x**2 - 8*x + 32/3, And(x <= 4, x >= 3)),
-                  (0, True))
+                  (0, true))
 
     By repeating knot points, you can introduce discontinuities in the
     B-splines and their derivatives:
@@ -60,7 +60,7 @@ def bspline_basis(d, knots, n, x, close=True):
         >>> d = 1
         >>> knots = [0,0,2,3,4]
         >>> bspline_basis(d, knots, 0, x)
-        Piecewise((-x/2 + 1, And(x <= 2, x >= 0)), (0, True))
+        Piecewise((-x/2 + 1, And(x <= 2, x >= 0)), (0, true))
 
     It is quite time consuming to construct and evaluate B-splines. If you
     need to evaluate a B-splines many times, it is best to lambdify them
@@ -138,11 +138,11 @@ def bspline_basis_set(d, knots, x):
     [Piecewise((x**2/2, And(x < 1, x >= 0)),
                (-x**2 + 3*x - 3/2, And(x < 2, x >= 1)),
                (x**2/2 - 3*x + 9/2, And(x <= 3, x >= 2)),
-               (0, True)),
+               (0, true)),
      Piecewise((x**2/2 - x + 1/2, And(x < 2, x >= 1)),
                (-x**2 + 5*x - 11/2, And(x < 3, x >= 2)),
                (x**2/2 - 4*x + 8, And(x <= 4, x >= 3)),
-               (0, True))]
+               (0, true))]
 
     See Also
     ========

--- a/sympy/geometry/tests/test_geometry.py
+++ b/sympy/geometry/tests/test_geometry.py
@@ -8,7 +8,7 @@ from sympy import (Abs, I, Dummy, Rational, Float, S, Symbol, cos, oo, pi,
 from sympy.functions.elementary.trigonometric import tan
 from sympy.geometry import (Circle, Curve, Ellipse, GeometryError, Line, Point,
                             Polygon, Ray, RegularPolygon, Segment, Triangle,
-                            are_similar, convex_hull, intersection,
+                            are_similar, convex_hull, intersection, Point2D,
                             Point3D, Line3D, Ray3D, Segment3D, Plane, centroid)
 from sympy.geometry.line import Undecidable
 from sympy.geometry.entity import rotate, scale, translate
@@ -721,7 +721,7 @@ def test_util():
 
 
 def test_repr():
-    assert repr(Circle((0, 1), 2)) == 'Circle(Point2D(0, 1), 2)'
+    assert repr(Circle((0, 1), 2)) == 'Circle(Point2D(Integer(0), Integer(1)), Integer(2))'
 
 
 def test_transform():
@@ -815,10 +815,17 @@ def test_reflect():
     rpent = pent.reflect(l)
     poly_pent = Polygon(*pent.vertices)
     assert rpent.center == pent.center.reflect(l)
-    assert str([w.n(3) for w in rpent.vertices]) == (
-        '[Point2D(-0.586, 4.27), Point2D(-1.69, 4.66), '
-        'Point2D(-2.41, 3.73), Point2D(-1.74, 2.76), '
-        'Point2D(-0.616, 3.10)]')
+    assert [w.n(3) for w in rpent.vertices] == \
+        [Point2D(Float('-0.585815', prec=3),
+                 Float('4.27051', prec=3)),
+         Point2D(Float('-1.69409', prec=3),
+                 Float('4.66211', prec=3)),
+         Point2D(Float('-2.40918', prec=3),
+                 Float('3.72949', prec=3)),
+         Point2D(Float('-1.74292', prec=3),
+                 Float('2.76123', prec=3)),
+         Point2D(Float('-0.615967', prec=3),
+                 Float('3.0957', prec=3))]
     assert pent.area.equals(-rpent.area)
 
 

--- a/sympy/geometry/tests/test_plane.py
+++ b/sympy/geometry/tests/test_plane.py
@@ -1,6 +1,6 @@
 import pytest
 
-from sympy import (Abs, I, Dummy, Rational, Float, Symbol, cos, oo, pi,
+from sympy import (Abs, I, Dummy, Rational, Float, Symbol, cos, oo, pi, sstr,
                    simplify, sin, sqrt, symbols, Derivative, asin, acos)
 from sympy.geometry import (Circle, Curve, Ellipse, GeometryError, Line, Point,
                             Polygon, Ray, RegularPolygon, Segment, Triangle,
@@ -195,5 +195,5 @@ def test_plane():
                (-Float(9.00000087501922), Float(-4.81170658872543e-13),
                 Float(0.0)))
 
-    assert str([i.n(2) for i in p2.intersection(l2)]) == \
+    assert sstr([i.n(2) for i in p2.intersection(l2)]) == \
            '[Point3D(4.0, -0.89, 2.3)]'

--- a/sympy/integrals/heurisch.py
+++ b/sympy/integrals/heurisch.py
@@ -106,7 +106,7 @@ def heurisch_wrapper(f, x, rewrite=False, hints=None, mappings=None, retries=3,
     >>> heurisch(cos(n*x), x)
     sin(n*x)/n
     >>> heurisch_wrapper(cos(n*x), x)
-    Piecewise((x, Eq(n, 0)), (sin(n*x)/n, True))
+    Piecewise((x, Eq(n, 0)), (sin(n*x)/n, true))
 
     See Also
     ========

--- a/sympy/integrals/integrals.py
+++ b/sympy/integrals/integrals.py
@@ -371,7 +371,7 @@ class Integral(AddWithLimits):
         >>> from sympy import Integral
         >>> from sympy.abc import x, i
         >>> Integral(x**i, (i, 1, 3)).doit()
-        Piecewise((2, Eq(log(x), 0)), (x**3/log(x) - x/log(x), True))
+        Piecewise((2, Eq(log(x), 0)), (x**3/log(x) - x/log(x), true))
 
         See Also
         ========
@@ -1214,7 +1214,7 @@ def integrate(*args, **kwargs):
 
     >>> integrate(x**a*exp(-x), (x, 0, oo)) # same as conds='piecewise'
     Piecewise((gamma(a + 1), -re(a) < 1),
-        (Integral(E**(-x)*x**a, (x, 0, oo)), True))
+        (Integral(E**(-x)*x**a, (x, 0, oo)), true))
 
     >>> integrate(x**a*exp(-x), (x, 0, oo), conds='none')
     gamma(a + 1)

--- a/sympy/integrals/manualintegrate.py
+++ b/sympy/integrals/manualintegrate.py
@@ -888,21 +888,16 @@ def integral_steps(integrand, symbol, **options):
     >>> from sympy.abc import x
     >>> print(repr(integral_steps(exp(x) / (1 + exp(2 * x)), x))) \
     # doctest: +NORMALIZE_WHITESPACE
-    URule(u_var=_u, u_func=E**x, constant=1,
-        substep=ArctanRule(context=1/(_u**2 + 1), symbol=_u),
-        context=E**x/(E**(2*x) + 1), symbol=x)
+    URule(u_var=Dummy('u'), u_func=Pow(E, Symbol('x')), constant=Integer(1),
+        substep=ArctanRule(context=Pow(Add(Pow(Dummy('u'), Integer(2)), Integer(1)), Integer(-1)),
+                           symbol=Dummy('u')),
+        context=Mul(Pow(E, Symbol('x')), Pow(Add(Pow(E, Mul(Integer(2), Symbol('x'))),
+                                                 Integer(1)),
+                                             Integer(-1))),
+        symbol=Symbol('x'))
     >>> print(repr(integral_steps(sin(x), x))) \
     # doctest: +NORMALIZE_WHITESPACE
-    TrigRule(func='sin', arg=x, context=sin(x), symbol=x)
-    >>> print(repr(integral_steps((x**2 + 3)**2 , x))) \
-    # doctest: +NORMALIZE_WHITESPACE
-    RewriteRule(rewritten=x**4 + 6*x**2 + 9,
-    substep=AddRule(substeps=[PowerRule(base=x, exp=4, context=x**4, symbol=x),
-        ConstantTimesRule(constant=6, other=x**2,
-            substep=PowerRule(base=x, exp=2, context=x**2, symbol=x),
-                context=6*x**2, symbol=x),
-        ConstantRule(constant=9, context=9, symbol=x)],
-    context=x**4 + 6*x**2 + 9, symbol=x), context=(x**2 + 3)**2, symbol=x)
+    TrigRule(func='sin', arg=Symbol('x'), context=sin(Symbol('x')), symbol=Symbol('x'))
 
     Returns
     =======

--- a/sympy/integrals/meijerint.py
+++ b/sympy/integrals/meijerint.py
@@ -1728,7 +1728,7 @@ def meijerint_definite(f, x, a, b):
     >>> from sympy import exp, oo
     >>> from sympy.abc import x
     >>> meijerint_definite(exp(-x**2), x, -oo, oo)
-    (sqrt(pi), True)
+    (sqrt(pi), true)
 
     This function is implemented as a succession of functions
     meijerint_definite, _meijerint_definite_2, _meijerint_definite_3,

--- a/sympy/logic/boolalg.py
+++ b/sympy/logic/boolalg.py
@@ -150,13 +150,13 @@ class BooleanTrue(BooleanAtom, metaclass=Singleton):
 
     >>> from sympy import sympify, true, Or
     >>> sympify(True)
-    True
+    true
     >>> ~true
-    False
+    false
     >>> ~True
     -2
     >>> Or(True, False)
-    True
+    true
 
     See Also
     ========
@@ -202,13 +202,13 @@ class BooleanFalse(BooleanAtom, metaclass=Singleton):
 
     >>> from sympy import sympify, false, Or, true
     >>> sympify(False)
-    False
+    false
     >>> false >> false
-    True
+    true
     >>> False >> False
     0
     >>> Or(True, False)
-    True
+    true
 
     See Also
     ========
@@ -441,13 +441,13 @@ class Not(BooleanFunction):
     >>> from sympy.logic.boolalg import Not, And, Or
     >>> from sympy.abc import x, A, B
     >>> Not(True)
-    False
+    false
     >>> Not(False)
-    True
+    true
     >>> Not(And(True, False))
-    True
+    true
     >>> Not(Or(True, False))
-    False
+    false
     >>> Not(And(And(True, x), Or(x, False)))
     Not(x)
     >>> ~x
@@ -470,8 +470,7 @@ class Not(BooleanFunction):
     >>> ~True
     -2
     >>> ~true
-    False
-
+    false
     """
 
     is_Not = True
@@ -572,13 +571,13 @@ class Xor(BooleanFunction):
     >>> from sympy import symbols
     >>> x, y = symbols('x y')
     >>> Xor(True, False)
-    True
+    true
     >>> Xor(True, True)
-    False
+    false
     >>> Xor(True, False, True, True, False)
-    True
+    true
     >>> Xor(True, False, True, False)
-    False
+    false
     >>> x ^ y
     Xor(x, y)
 
@@ -672,12 +671,11 @@ class Nand(BooleanFunction):
     >>> from sympy import symbols
     >>> x, y = symbols('x y')
     >>> Nand(False, True)
-    True
+    true
     >>> Nand(True, True)
-    False
+    false
     >>> Nand(x, y)
     Not(And(x, y))
-
     """
     @classmethod
     def eval(cls, *args):
@@ -702,16 +700,15 @@ class Nor(BooleanFunction):
     >>> x, y = symbols('x y')
 
     >>> Nor(True, False)
-    False
+    false
     >>> Nor(True, True)
-    False
+    false
     >>> Nor(False, True)
-    False
+    false
     >>> Nor(False, False)
-    True
+    true
     >>> Nor(x, y)
     Not(Or(x, y))
-
     """
     @classmethod
     def eval(cls, *args):
@@ -736,13 +733,13 @@ class Implies(BooleanFunction):
     >>> x, y = symbols('x y')
 
     >>> Implies(True, False)
-    False
+    false
     >>> Implies(False, False)
-    True
+    true
     >>> Implies(True, True)
-    True
+    true
     >>> Implies(False, True)
-    True
+    true
     >>> x >> y
     Implies(x, y)
     >>> y << x
@@ -763,8 +760,7 @@ class Implies(BooleanFunction):
     >>> True >> False
     1
     >>> true >> false
-    False
-
+    false
     """
     @classmethod
     def eval(cls, *args):
@@ -812,11 +808,11 @@ class Equivalent(BooleanFunction):
     >>> from sympy.logic.boolalg import Equivalent, And
     >>> from sympy.abc import x, y
     >>> Equivalent(False, False, False)
-    True
+    true
     >>> Equivalent(True, False, False)
-    False
+    false
     >>> Equivalent(x, And(x, True))
-    True
+    true
     """
     def __new__(cls, *args, **options):
         from sympy.core.relational import Relational
@@ -883,9 +879,9 @@ class ITE(BooleanFunction):
     >>> from sympy.logic.boolalg import ITE, And, Xor, Or
     >>> from sympy.abc import x, y, z
     >>> ITE(True, False, True)
-    False
+    false
     >>> ITE(Or(True, False), And(True, True), Xor(True, True))
-    True
+    true
     >>> ITE(x, y, z)
     ITE(x, y, z)
     >>> ITE(True, x, y)

--- a/sympy/logic/inference.py
+++ b/sympy/logic/inference.py
@@ -54,7 +54,7 @@ def satisfiable(expr, algorithm="dpll2", all_models=False):
     >>> satisfiable(A & ~A)
     False
     >>> satisfiable(True)
-    {True: True}
+    {true: True}
     >>> next(satisfiable(A & ~A, all_models=True))
     False
     >>> models = satisfiable((A >> B) & B, all_models=True)

--- a/sympy/logic/inference.py
+++ b/sympy/logic/inference.py
@@ -66,7 +66,7 @@ def satisfiable(expr, algorithm="dpll2", all_models=False):
     ...     for model in models:
     ...         if model:
     ...             # Do something with the model.
-    ...             print(model)
+    ...             return model
     ...         else:
     ...             # Given expr is unsatisfiable.
     ...             print("UNSAT")

--- a/sympy/matrices/dense.py
+++ b/sympy/matrices/dense.py
@@ -998,7 +998,7 @@ def symarray(prefix, shape):  # pragma: no cover
     These doctests require numpy.
 
     >>> from sympy import symarray
-    >>> print(symarray('', 3))
+    >>> symarray('', 3)
     [_0 _1 _2]
 
     If you want multiple symarrays to contain distinct symbols, you *must*
@@ -1015,15 +1015,15 @@ def symarray(prefix, shape):  # pragma: no cover
 
     Creating symarrays with a prefix:
 
-    >>> print(symarray('a', 3))
+    >>> symarray('a', 3)
     [a_0 a_1 a_2]
 
     For more than one dimension, the shape must be given as a tuple:
 
-    >>> print(symarray('a', (2, 3)))
+    >>> symarray('a', (2, 3))
     [[a_0_0 a_0_1 a_0_2]
      [a_1_0 a_1_1 a_1_2]]
-    >>> print(symarray('a', (2, 3, 2)))
+    >>> symarray('a', (2, 3, 2))
     [[[a_0_0_0 a_0_0_1]
       [a_0_1_0 a_0_1_1]
       [a_0_2_0 a_0_2_1]]
@@ -1031,7 +1031,6 @@ def symarray(prefix, shape):  # pragma: no cover
      [[a_1_0_0 a_1_0_1]
       [a_1_1_0 a_1_1_1]
       [a_1_2_0 a_1_2_1]]]
-
     """
     from numpy import empty, ndindex
     arr = empty(shape, dtype=object)

--- a/sympy/matrices/matrices.py
+++ b/sympy/matrices/matrices.py
@@ -688,8 +688,8 @@ class MatrixBase(object):
     # Note, we always use the default ordering (lex) in __str__ and __repr__,
     # regardless of the global setting.  See issue 5487.
     def __repr__(self):
-        from sympy.printing import sstr
-        return sstr(self, order=None)
+        from sympy.printing import srepr
+        return srepr(self, order=None)
 
     def __str__(self):
         from sympy.printing import sstr

--- a/sympy/polys/agca/homomorphisms.py
+++ b/sympy/polys/agca/homomorphisms.py
@@ -9,6 +9,7 @@ the function ``homomorphism(from, to, matrix)`` to create homomorphism objects.
 from sympy.polys.agca.modules import (Module, FreeModule, QuotientModule,
                                       SubModule, SubQuotientModule)
 from sympy.polys.polyerrors import CoercionFailed
+from sympy.printing import sstr
 
 # The main computational task for module homomorphisms is kernels.
 # For this reason, the concrete classes are organised by domain module type.
@@ -466,7 +467,7 @@ class MatrixHomomorphism(ModuleHomomorphism):
         return Matrix([[self.ring.to_sympy(y) for y in c(x)] for x in self.matrix]).T
 
     def __repr__(self):
-        lines = repr(self._sympy_matrix()).split('\n')
+        lines = sstr(self._sympy_matrix()).split('\n')
         t = " : %s -> %s" % (self.domain, self.codomain)
         s = ' '*len(t)
         n = len(lines)

--- a/sympy/polys/domains/field.py
+++ b/sympy/polys/domains/field.py
@@ -46,13 +46,12 @@ class Field(Ring):
         >>> from sympy import Rational, gcd, primitive
         >>> from sympy.abc import x
 
-        >>> print(QQ.gcd(QQ(2, 3), QQ(4, 9)))
+        >>> QQ.gcd(QQ(2, 3), QQ(4, 9))
         2/9
-        >>> print(gcd(Rational(2, 3), Rational(4, 9)))
+        >>> gcd(Rational(2, 3), Rational(4, 9))
         2/9
-        >>> print(primitive(2*x/3 + Rational(4, 9)))
+        >>> primitive(2*x/3 + Rational(4, 9))
         (2/9, 3*x + 2)
-
         """
         try:
             ring = self.get_ring()

--- a/sympy/polys/orderings.py
+++ b/sympy/polys/orderings.py
@@ -14,7 +14,10 @@ class MonomialOrder(object):
     is_default = False
 
     def __repr__(self):
-        return self.__class__.__name__ + "()"
+        if self.alias:
+            return str(self)
+        else:
+            return self.__class__.__name__ + "()"
 
     def __str__(self):
         return self.alias

--- a/sympy/printing/dot.py
+++ b/sympy/printing/dot.py
@@ -1,4 +1,4 @@
-from sympy import Basic, Expr, srepr
+from sympy import Basic, Expr
 
 __all__ = ['dotprint']
 
@@ -53,7 +53,7 @@ def dotnode(expr, styles=default_styles, labelfunc=str, pos=(), repeat=True):
     else:
         label = labelfunc(expr)
     style['label'] = label
-    expr_str = srepr(expr)
+    expr_str = repr(expr)
     if repeat:
         expr_str += '_%s' % str(pos)
     return '"%s" [%s];' % (expr_str, attrprint(style))
@@ -74,8 +74,8 @@ def dotedges(expr, atom=lambda x: not isinstance(x, Basic), pos=(), repeat=True)
     if atom(expr):
         return []
     else:
-        expr_str = srepr(expr)
-        arg_strs = [srepr(arg) for arg in expr.args]
+        expr_str = repr(expr)
+        arg_strs = [repr(arg) for arg in expr.args]
         if repeat:
             expr_str += '_%s' % str(pos)
             arg_strs = [arg_str + '_%s' % str(pos + (i,)) for i, arg_str in enumerate(arg_strs)]
@@ -131,8 +131,8 @@ def dotprint(expr, styles=default_styles,
           object might not equal the number of args it has).
 
     ``labelfunc``: How to label leaf nodes.  The default is ``str``.  Another
-          good option is ``srepr``. For example with ``str``, the leaf nodes
-          of ``x + 1`` are labeled, ``x`` and ``1``.  With ``srepr``, they
+          good option is ``repr``. For example with ``str``, the leaf nodes
+          of ``x + 1`` are labeled, ``x`` and ``1``.  With ``repr``, they
           are labeled ``Symbol('x')`` and ``Integer(1)``.
 
     Additional keyword arguments are included as styles for the graph.

--- a/sympy/printing/printer.py
+++ b/sympy/printing/printer.py
@@ -186,6 +186,8 @@ class Printer(object):
     printmethod = None
 
     def __init__(self, settings=None):
+        from sympy.external import import_module
+
         self._str = str
 
         self._settings = self._default_settings.copy()
@@ -205,6 +207,11 @@ class Printer(object):
         # _print_level is the number of times self._print() was recursively
         # called. See StrPrinter._print_Float() for an example of usage
         self._print_level = 0
+
+        numpy = import_module("numpy")
+        if numpy is not None:
+            formatter = {'numpystr': str}
+            numpy.set_printoptions(formatter=formatter)
 
     @classmethod
     def set_global_settings(cls, **settings):

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -9,6 +9,7 @@ import mpmath.libmp as mlib
 from mpmath.libmp import prec_to_dps, repr_dps
 
 from sympy.core.function import AppliedUndef
+from sympy.core.compatibility import default_sort_key
 from .printer import Printer
 
 
@@ -42,6 +43,12 @@ class ReprPrinter(Printer):
             return "<'%s.%s'>" % (expr.__module__, expr.__name__)
         else:
             return repr(expr)
+
+    def _print_Dict(self, expr):
+        l = []
+        for o in sorted(expr.args, key=default_sort_key):
+            l.append(self._print(o))
+        return expr.__class__.__name__ + '(%s)' % ', '.join(l)
 
     def _print_Add(self, expr, order=None):
         args = expr.as_ordered_terms(order=order or self.order)

--- a/sympy/printing/repr.py
+++ b/sympy/printing/repr.py
@@ -41,7 +41,7 @@ class ReprPrinter(Printer):
         elif hasattr(expr, "__module__") and hasattr(expr, "__name__"):
             return "<'%s.%s'>" % (expr.__module__, expr.__name__)
         else:
-            return str(expr)
+            return repr(expr)
 
     def _print_Add(self, expr, order=None):
         args = expr.as_ordered_terms(order=order or self.order)

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -66,10 +66,10 @@ class StrPrinter(Printer):
         return sign + ' '.join(l)
 
     def _print_BooleanTrue(self, expr):
-        return "True"
+        return "true"
 
     def _print_BooleanFalse(self, expr):
-        return "False"
+        return "false"
 
     def _print_And(self, expr):
         return '%s(%s)' % (expr.func, ', '.join(sorted(self._print(a) for a in

--- a/sympy/printing/str.py
+++ b/sympy/printing/str.py
@@ -35,7 +35,7 @@ class StrPrinter(Printer):
             return expr
         elif isinstance(expr, Basic):
             if hasattr(expr, "args"):
-                return repr(expr)
+                return str(expr)
             else:
                 raise
         else:

--- a/sympy/printing/tests/test_latex.py
+++ b/sympy/printing/tests/test_latex.py
@@ -119,8 +119,8 @@ def test_latex_builtins():
     assert latex(True) == r"\mathrm{True}"
     assert latex(False) == r"\mathrm{False}"
     assert latex(None) == r"\mathrm{None}"
-    assert latex(true) == r"\mathrm{True}"
-    assert latex(false) == r'\mathrm{False}'
+    assert latex(true) == r"\mathrm{true}"
+    assert latex(false) == r'\mathrm{false}'
 
 
 def test_latex_Float():

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -696,8 +696,8 @@ def test_MatrixSlice():
 
 
 def test_true_false():
-    assert str(true) == repr(true) == sstr(true) == "True"
-    assert str(false) == repr(false) == sstr(false) == "False"
+    assert str(true) == repr(true) == sstr(true) == "true"
+    assert str(false) == repr(false) == sstr(false) == "false"
 
 
 def test_Equivalent():

--- a/sympy/printing/tests/test_str.py
+++ b/sympy/printing/tests/test_str.py
@@ -67,8 +67,9 @@ def test_Derivative():
 
 
 def test_dict():
-    assert str({1: 1 + x}) == sstr({1: 1 + x}) == "{1: x + 1}"
-    assert str({1: x**2, 2: y*x}) in ("{1: x**2, 2: x*y}", "{2: x*y, 1: x**2}")
+    assert sstr({1: 1 + x}) == "{1: x + 1}"
+    assert str({1: 1 + x}) == "{1: Add(Symbol('x'), Integer(1))}"
+    assert str({1: x**2, 2: y*x}) in ("{1: Pow(Symbol('x'), Integer(2)), 2: Mul(Symbol('x'), Symbol('y'))}", "{1: Mul(Symbol('x'), Symbol('y')), 2: Pow(Symbol('x'), Integer(2))}")
     assert sstr({1: x**2, 2: y*x}) == "{1: x**2, 2: x*y}"
 
 
@@ -173,9 +174,12 @@ def test_Limit():
 
 
 def test_list():
-    assert str([x]) == sstr([x]) == "[x]"
-    assert str([x**2, x*y + 1]) == sstr([x**2, x*y + 1]) == "[x**2, x*y + 1]"
-    assert str([x**2, [y + x]]) == sstr([x**2, [y + x]]) == "[x**2, [x + y]]"
+    assert sstr([x]) == "[x]"
+    assert str([x]) == "[Symbol('x')]"
+    assert sstr([x**2, x*y + 1]) == "[x**2, x*y + 1]"
+    assert str([x**2, x*y + 1]) == "[Pow(Symbol('x'), Integer(2)), Add(Mul(Symbol('x'), Symbol('y')), Integer(1))]"
+    assert sstr([x**2, [y + x]]) == "[x**2, [x + y]]"
+    assert str([x**2, [y + x]]) == "[Pow(Symbol('x'), Integer(2)), [Add(Symbol('x'), Symbol('y'))]]"
 
 
 def test_Matrix_str():
@@ -536,10 +540,12 @@ def test_Symbol():
 
 
 def test_tuple():
-    assert str((x,)) == sstr((x,)) == "(x,)"
-    assert str((x + y, 1 + x)) == sstr((x + y, 1 + x)) == "(x + y, x + 1)"
-    assert str((x + y, (
-        1 + x, x**2))) == sstr((x + y, (1 + x, x**2))) == "(x + y, (x + 1, x**2))"
+    assert sstr((x,)) == "(x,)"
+    assert str((x,)) == "(Symbol('x'),)"
+    assert sstr((x + y, 1 + x)) == "(x + y, x + 1)"
+    assert str((x + y, 1 + x)) == "(Add(Symbol('x'), Symbol('y')), Add(Symbol('x'), Integer(1)))"
+    assert sstr((x + y, (1 + x, x**2))) == "(x + y, (x + 1, x**2))"
+    assert str((x + y, (1 + x, x**2))) == "(Add(Symbol('x'), Symbol('y')), (Add(Symbol('x'), Integer(1)), Pow(Symbol('x'), Integer(2))))"
 
 
 def test_wild_str():

--- a/sympy/sets/contains.py
+++ b/sympy/sets/contains.py
@@ -12,9 +12,9 @@ class Contains(BooleanFunction):
     >>> from sympy import Symbol, Integer, S
     >>> from sympy.sets.contains import Contains
     >>> Contains(Integer(2), S.Integers)
-    True
+    true
     >>> Contains(Integer(-2), S.Naturals)
-    False
+    false
     >>> i = Symbol('i', integer=True)
     >>> Contains(i, S.Naturals)
     Contains(i, Naturals())

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -257,7 +257,7 @@ class Set(Basic):
 
         >>> from sympy import Interval
         >>> Interval(0, 1).contains(0.5)
-        True
+        true
         >>> 0.5 in Interval(0, 1)
         True
         """
@@ -777,9 +777,9 @@ class Interval(Set, EvalfMixin):
 
         >>> from sympy import Interval
         >>> Interval(0, 1, left_open=True).left_open
-        True
+        true
         >>> Interval(0, 1, left_open=False).left_open
-        False
+        false
         """
         return self._args[2]
 
@@ -793,9 +793,9 @@ class Interval(Set, EvalfMixin):
 
         >>> from sympy import Interval
         >>> Interval(0, 1, right_open=True).right_open
-        True
+        true
         >>> Interval(0, 1, right_open=False).right_open
-        False
+        false
         """
         return self._args[3]
 

--- a/sympy/simplify/cse_main.py
+++ b/sympy/simplify/cse_main.py
@@ -156,7 +156,7 @@ def opt_cse(exprs, order='canonical'):
     >>> from sympy.simplify.cse_main import opt_cse
     >>> from sympy.abc import x
     >>> opt_subs = opt_cse([x**-2])
-    >>> print(opt_subs)
+    >>> opt_subs
     {x**(-2): 1/(x**2)}
     """
     opt_subs = dict()

--- a/sympy/simplify/hyperexpand.py
+++ b/sympy/simplify/hyperexpand.py
@@ -83,6 +83,7 @@ from sympy.functions.elementary.complexes import polarify, unpolarify
 from sympy.simplify.powsimp import powdenest
 from sympy.polys import poly, Poly
 from sympy.series import residue
+from sympy.printing import sstr
 
 # function to define "buckets"
 
@@ -995,7 +996,7 @@ class ShiftA(Operator):
         self._poly = Poly(_x/ai + 1, _x)
 
     def __str__(self):
-        return '<Increment upper %s.>' % (1/self._poly.all_coeffs()[0])
+        return '<Increment upper %s.>' % sstr(1/self._poly.all_coeffs()[0])
 
 
 class ShiftB(Operator):
@@ -1008,7 +1009,7 @@ class ShiftB(Operator):
         self._poly = Poly(_x/(bi - 1) + 1, _x)
 
     def __str__(self):
-        return '<Decrement lower %s.>' % (1/self._poly.all_coeffs()[0] + 1)
+        return '<Decrement lower %s.>' % sstr(1/self._poly.all_coeffs()[0] + 1)
 
 
 class UnShiftA(Operator):
@@ -1048,8 +1049,8 @@ class UnShiftA(Operator):
         self._poly = Poly((n - m)/b0, _x)
 
     def __str__(self):
-        return '<Decrement upper index #%s of %s, %s.>' % (self._i,
-                                                        self._ap, self._bq)
+        return '<Decrement upper index #%s of %s, %s.>' % (sstr(self._i),
+                                                           sstr(self._ap), sstr(self._bq))
 
 
 class UnShiftB(Operator):
@@ -1090,8 +1091,8 @@ class UnShiftB(Operator):
         self._poly = Poly((m - n)/b0, _x)
 
     def __str__(self):
-        return '<Increment lower index #%s of %s, %s.>' % (self._i,
-                                                        self._ap, self._bq)
+        return '<Increment lower index #%s of %s, %s.>' % (sstr(self._i),
+                                                           sstr(self._ap), sstr(self._bq))
 
 
 class MeijerShiftA(Operator):
@@ -1102,7 +1103,7 @@ class MeijerShiftA(Operator):
         self._poly = Poly(bi - _x, _x)
 
     def __str__(self):
-        return '<Increment upper b=%s.>' % (self._poly.all_coeffs()[1])
+        return '<Increment upper b=%s.>' % sstr(self._poly.all_coeffs()[1])
 
 
 class MeijerShiftB(Operator):
@@ -1113,7 +1114,7 @@ class MeijerShiftB(Operator):
         self._poly = Poly(1 - bi + _x, _x)
 
     def __str__(self):
-        return '<Decrement upper a=%s.>' % (1 - self._poly.all_coeffs()[1])
+        return '<Decrement upper a=%s.>' % sstr(1 - self._poly.all_coeffs()[1])
 
 
 class MeijerShiftC(Operator):
@@ -1124,7 +1125,7 @@ class MeijerShiftC(Operator):
         self._poly = Poly(-bi + _x, _x)
 
     def __str__(self):
-        return '<Increment lower b=%s.>' % (-self._poly.all_coeffs()[1])
+        return '<Increment lower b=%s.>' % sstr(-self._poly.all_coeffs()[1])
 
 
 class MeijerShiftD(Operator):
@@ -1135,7 +1136,7 @@ class MeijerShiftD(Operator):
         self._poly = Poly(bi - 1 - _x, _x)
 
     def __str__(self):
-        return '<Decrement lower a=%s.>' % (self._poly.all_coeffs()[1] + 1)
+        return '<Decrement lower a=%s.>' % sstr(self._poly.all_coeffs()[1] + 1)
 
 
 class MeijerUnShiftA(Operator):
@@ -1180,8 +1181,8 @@ class MeijerUnShiftA(Operator):
         self._poly = Poly((m - n)/b0, _x)
 
     def __str__(self):
-        return '<Decrement upper b index #%s of %s, %s, %s, %s.>' % (self._i,
-                                      self._an, self._ap, self._bm, self._bq)
+        return '<Decrement upper b index #%s of %s, %s, %s, %s.>' % (sstr(self._i),
+                                      sstr(self._an), sstr(self._ap), sstr(self._bm), sstr(self._bq))
 
 
 class MeijerUnShiftB(Operator):
@@ -1227,8 +1228,8 @@ class MeijerUnShiftB(Operator):
         self._poly = Poly((m - n)/b0, _x)
 
     def __str__(self):
-        return '<Increment upper a index #%s of %s, %s, %s, %s.>' % (self._i,
-                                      self._an, self._ap, self._bm, self._bq)
+        return '<Increment upper a index #%s of %s, %s, %s, %s.>' % (sstr(self._i),
+                                      sstr(self._an), sstr(self._ap), sstr(self._bm), sstr(self._bq))
 
 
 class MeijerUnShiftC(Operator):
@@ -1278,8 +1279,8 @@ class MeijerUnShiftC(Operator):
         self._poly = Poly((m - n)/b0, _x)
 
     def __str__(self):
-        return '<Decrement lower b index #%s of %s, %s, %s, %s.>' % (self._i,
-                                      self._an, self._ap, self._bm, self._bq)
+        return '<Decrement lower b index #%s of %s, %s, %s, %s.>' % (sstr(self._i),
+                                      sstr(self._an), sstr(self._ap), sstr(self._bm), sstr(self._bq))
 
 
 class MeijerUnShiftD(Operator):
@@ -1327,8 +1328,8 @@ class MeijerUnShiftD(Operator):
         self._poly = Poly((m - n)/b0, _x)
 
     def __str__(self):
-        return '<Increment lower a index #%s of %s, %s, %s, %s.>' % (self._i,
-                                      self._an, self._ap, self._bm, self._bq)
+        return '<Increment lower a index #%s of %s, %s, %s, %s.>' % (sstr(self._i),
+                                      sstr(self._an), sstr(self._ap), sstr(self._bm), sstr(self._bq))
 
 
 class ReduceOrder(Operator):
@@ -1392,7 +1393,7 @@ class ReduceOrder(Operator):
 
     def __str__(self):
         return '<Reduce order by cancelling upper %s with lower %s.>' % \
-            (self._a, self._b)
+            (sstr(self._a), sstr(self._b))
 
 
 def _reduce_order(ap, bq, gen, key):

--- a/sympy/simplify/hyperexpand.py
+++ b/sympy/simplify/hyperexpand.py
@@ -1523,10 +1523,10 @@ def devise_plan(target, origin, z):
     Very simple plans:
 
     >>> for i in devise_plan(Hyper_Function((2,), ()), Hyper_Function((1,), ()), z):
-    ...     print(i)
+    ...     i
     <Increment upper 1.>
     >>> for i in devise_plan(Hyper_Function((), (2,)), Hyper_Function((), (1,)), z):
-    ...     print(i)
+    ...     i
     <Increment lower index #0 of [], [1].>
 
     Several buckets:
@@ -1534,21 +1534,21 @@ def devise_plan(target, origin, z):
     >>> from sympy import S
     >>> for i in devise_plan(Hyper_Function((1, S.Half), ()),
     ...             Hyper_Function((2, Rational(3, 2)), ()), z):
-    ...     print(i)
+    ...     i
     <Decrement upper index #0 of [3/2, 1], [].>
     <Decrement upper index #0 of [2, 3/2], [].>
 
     A slightly more complicated plan:
 
     >>> for i in devise_plan(Hyper_Function((1, 3), ()), Hyper_Function((2, 2), ()), z):
-    ...     print(i)
+    ...     i
     <Increment upper 2.>
     <Decrement upper index #0 of [2, 2], [].>
 
     Another more complicated plan: (note that the ap have to be shifted first!)
 
     >>> for i in devise_plan(Hyper_Function((1, -1), (2,)), Hyper_Function((3, -2), (4,)), z):
-    ...     print(i)
+    ...     i
     <Decrement lower 3.>
     <Decrement lower 4.>
     <Decrement upper index #1 of [-1, 2], [4].>

--- a/sympy/simplify/tests/test_simplify.py
+++ b/sympy/simplify/tests/test_simplify.py
@@ -8,7 +8,7 @@ from sympy import (
     logcombine, Matrix, MatrixSymbol, Mul, nsimplify, O, oo, pi, Piecewise,
     posify, rad, Rational, root, S, separatevars, signsimp, simplify,
     sin, sinh, solve, sqrt, Symbol, symbols, sympify, tan, tanh,
-    zoo, Sum, Lt, Integer)
+    zoo, Sum, Lt, Integer, sstr)
 from sympy.core.mul import _keep_coeff
 from sympy.simplify.simplify import nthroot
 
@@ -420,7 +420,7 @@ def test_logcombine_complex_coeff():
 def test_posify():
     from sympy.abc import x
 
-    assert str(posify(
+    assert sstr(posify(
         x +
         Symbol('p', positive=True) +
         Symbol('n', negative=True))) == '(n + p + _x, {_x: x})'
@@ -430,19 +430,19 @@ def test_posify():
     # force=True option can do so as well when it is implemented.
     eq, rep = posify(1/x)
     assert log(eq).expand().subs(rep) == -log(x)
-    assert str(posify([x, 1 + x])) == '([_x, _x + 1], {_x: x})'
+    assert sstr(posify([x, 1 + x])) == '([_x, _x + 1], {_x: x})'
 
     x = symbols('x')
     p = symbols('p', positive=True)
     n = symbols('n', negative=True)
     orig = [x, n, p]
     modified, reps = posify(orig)
-    assert str(modified) == '[_x, n, p]'
+    assert sstr(modified) == '[_x, n, p]'
     assert [w.subs(reps) for w in modified] == orig
 
-    assert str(Integral(posify(1/x + y)[0], (y, 1, 3)).expand()) == \
+    assert sstr(Integral(posify(1/x + y)[0], (y, 1, 3)).expand()) == \
         'Integral(1/_x, (y, 1, 3)) + Integral(_y, (y, 1, 3))'
-    assert str(Sum(posify(1/x**n)[0], (n,1,3)).expand()) == \
+    assert sstr(Sum(posify(1/x**n)[0], (n,1,3)).expand()) == \
         'Sum(_x**(-n), (n, 1, 3))'
 
 

--- a/sympy/solvers/solvers.py
+++ b/sympy/solvers/solvers.py
@@ -592,7 +592,7 @@ def solve(f, *symbols, **flags):
             >>> solve([x < 3, x - 2])
             Eq(x, 2)
             >>> solve([x > 3, x - 2])
-            False
+            false
 
         * when the system is linear
 

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -4,7 +4,7 @@ import pytest
 
 from sympy import (acos, acosh, asinh, atan, cos, Derivative, diff, dsolve,
                    Dummy, Eq, erf, erfi, exp, Function, I, Integral, LambertW,
-                   log, O, pi, Rational, RootOf, S, simplify, sin, sqrt,
+                   log, O, pi, Rational, RootOf, S, simplify, sin, sqrt, sstr,
                    Symbol, tan, asin, sinh, Piecewise, symbols, Poly, Integer)
 from sympy.solvers.ode import (_undetermined_coefficients_match, checkodesol,
                                classify_ode, classify_sysode, constant_renumber,
@@ -218,7 +218,7 @@ def test_linear_2eq_order2():
     "4*C1*t*(-sqrt(133)*t**3/12 - t**3/12 + 1) + O(t**6))/3192), Eq(y(t), -sqrt(133)*(-C2*(133*t**8/24 - t**3/6 + "
     "sqrt(133)*t**3/2 + 1) + C2*(-sqrt(133)*t**3/6 - t**3/6 + 1) - C1*t*(sqrt(133)*t**4/6 - t**3/12 + 1) + "
     "C1*t*(-sqrt(133)*t**3/12 - t**3/12 + 1) + O(t**6))/266)]")
-    assert str(dsolve(eq8)) == sol8
+    assert sstr(dsolve(eq8)) == sol8
 
     eq9 = (Eq(diff(x(t),t,t), t*(4*diff(x(t),t) + 9*diff(y(t),t))), Eq(diff(y(t),t,t), t*(12*diff(x(t),t) - 6*diff(y(t),t))))
     sol9 = [Eq(x(t), -sqrt(133)*(4*C1*Integral(exp((-sqrt(133) - 1)*Integral(t, t)), t) + 4*C2 -
@@ -550,14 +550,14 @@ def test_nonlinear_3eq_order1():
     "C3 + Integral(-sqrt(15)/15, t))), Eq(y(t), Eq(Integral(3/(sqrt(-C1 + 5*C2 - 6*_y**2)*sqrt(C1 - 4*C2 + 3*_y**2)), "\
     "(_y, y(t))), C3 + Integral(sqrt(5)/10, t))), Eq(z(t), Eq(Integral(5/(sqrt(-3*C1 + C2 - 10*_y**2)*"\
     "sqrt(4*C1 - C2 + 5*_y**2)), (_y, z(t))), C3 + Integral(sqrt(3)/6, t)))]"
-    assert str(dsolve(eq1)) == sol1
+    assert sstr(dsolve(eq1)) == sol1
 
     eq2 = (4*diff(x(t),t) + 2*y(t)*z(t)*sin(t), 3*diff(y(t),t) - z(t)*x(t)*sin(t), 5*diff(z(t),t) - x(t)*y(t)*sin(t))
     sol2 = "[Eq(x(t), Eq(Integral(3/(sqrt(-C1 + 5*C2 - 6*_y**2)*sqrt(C1 - 4*C2 + 3*_y**2)), (_y, x(t))), C3 + "\
     "Integral(-sqrt(5)*sin(t)/10, t))), Eq(y(t), Eq(Integral(4/(sqrt(-3*C1 + C2 - 4*_y**2)*sqrt(5*C1 - C2 - 4*_y**2)), "\
     "(_y, y(t))), C3 + Integral(sqrt(15)*sin(t)/15, t))), Eq(z(t), Eq(Integral(5/(sqrt(-3*C1 + C2 - 10*_y**2)*"\
     "sqrt(4*C1 - C2 + 5*_y**2)), (_y, z(t))), C3 + Integral(-sqrt(3)*sin(t)/6, t)))]"
-    assert str(dsolve(eq2)) == sol2
+    assert sstr(dsolve(eq2)) == sol2
 
 
 def test_checkodesol():

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -426,7 +426,7 @@ def test_solve_transcendental():
 
     # issue 7602
     a, b = symbols('a, b', extended_real=True, negative=False)
-    assert str(solve(Eq(a, 0.5 - cos(pi*b)/2), b)) == \
+    assert sstr(solve(Eq(a, 0.5 - cos(pi*b)/2), b)) == \
         '[-0.318309886183791*acos(-2.0*a + 1.0) + 2.0, 0.318309886183791*acos(-2.0*a + 1.0)]'
 
 

--- a/sympy/stats/crv_types.py
+++ b/sympy/stats/crv_types.py
@@ -827,7 +827,7 @@ def Exponential(name, rate):
     E**(-lambda*z)*lambda
 
     >>> cdf(X)(z)
-    Piecewise((1 - E**(-lambda*z), z >= 0), (0, True))
+    Piecewise((1 - E**(-lambda*z), z >= 0), (0, true))
 
     >>> E(X)
     1/lambda
@@ -2218,7 +2218,7 @@ def Uniform(name, left, right):
     >>> X = Uniform("x", a, b)
 
     >>> density(X)(z)
-    Piecewise((1/(-a + b), And(a <= z, z <= b)), (0, True))
+    Piecewise((1/(-a + b), And(a <= z, z <= b)), (0, true))
 
     >>> cdf(X)(z)  # doctest: +SKIP
     -a/(-a + b) + z/(-a + b)

--- a/sympy/tensor/tensor.py
+++ b/sympy/tensor/tensor.py
@@ -410,7 +410,8 @@ class TIDS(CantSympify):
         return TIDS(*self.mul(self, other))
 
     def __str__(self):
-        return "TIDS({0}, {1}, {2})".format(self.components, self.free, self.dum)
+        from sympy import sstr
+        return "TIDS({0}, {1}, {2})".format(sstr(self.components), sstr(self.free), sstr(self.dum))
 
     def __repr__(self):
         return self.__str__()

--- a/sympy/utilities/lambdify.py
+++ b/sympy/utilities/lambdify.py
@@ -195,8 +195,8 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
     >>> array2mat = [{'ImmutableMatrix': numpy.matrix}, 'numpy']
     >>> f = lambdify((x, y), Matrix([x, y]), modules=array2mat)
     >>> f(1, 2)
-    matrix([[1],
-            [2]])
+    [[1]
+     [2]]
 
     Usage
     =====
@@ -226,10 +226,10 @@ def lambdify(args, expr, modules=None, printer=None, use_imps=True,
 
         >>> f = lambdify((x,y), tan(x*y), "numpy")
         >>> f(1, 2)
-        -2.1850398632615189
+        -2.18503986326
         >>> from numpy import array
         >>> f(array([1, 2, 3]), array([2, 3, 5]))
-        array([-2.18503986, -0.29100619, -0.8559934 ])
+        [-2.18503986 -0.29100619 -0.8559934 ]
 
     (3) Use a dictionary defining custom functions:
 

--- a/sympy/utilities/randtest.py
+++ b/sympy/utilities/randtest.py
@@ -41,7 +41,7 @@ def verify_numerically(f, g, z=None, tol=1.0e-6, a=2, b=-1, c=3, d=1):
     >>> from sympy.abc import x
     >>> from sympy.utilities.randtest import verify_numerically as tn
     >>> tn(sin(x)**2 + cos(x)**2, 1, x)
-    True
+    true
     """
     f, g, z = Tuple(f, g, z)
     z = [z] if isinstance(z, Symbol) else (f.free_symbols | g.free_symbols)
@@ -67,7 +67,7 @@ def test_derivative_numerically(f, z, tol=1.0e-6, a=2, b=-1, c=3, d=1):
     >>> from sympy.abc import x
     >>> from sympy.utilities.randtest import test_derivative_numerically as td
     >>> td(sin(x), x)
-    True
+    true
     """
     from sympy.core.function import Derivative
     z0 = random_complex_number(a, b, c, d)


### PR DESCRIPTION
see https://github.com/skirpichev/omg/issues/32

- [x] fix tests
- [x] document repr behavior in docs
- [x] fix polys repr methods (e.g. SubModule.__repr__ returns things like '<x>')
- [x] rebase

most test failures because container’s \__str__ uses contained objects’ \__repr__.  I.e. see [this](http://stackoverflow.com/questions/1436703/difference-between-str-and-repr-in-python/2626364#2626364).

See also:
https://www.python.org/dev/peps/pep-3140/
https://groups.google.com/forum/#!topic/python-ideas/ChVbmWhlqJA