### PR TITLE
Revert "Removing Kirill from credits."

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -12,8 +12,9 @@ Ondřej Čertík <ondrej@certik.cz> ondrej.certik <devnull@localhost>
 Ondřej Čertík <ondrej@certik.cz> Ondrej Certik <ondrej.certik@gmail.com>
 Ondřej Čertík <ondrej@certik.cz> Ondřej Čertík <ondrej.certik@gmail.com>
 Fredrik Johansson <fredrik.johansson@gmail.com> fredrik.johansson <devnull@localhost>
-Kirill Smelkov <kirr@landau.phys.spbu.ru> kirill.smelkov <devnull@localhost>
-Kirill Smelkov <kirr@landau.phys.spbu.ru> convert-repo <devnull@localhost>
+Kirill Smelkov <kirr@nexedi.com> kirill.smelkov <devnull@localhost>
+Kirill Smelkov <kirr@nexedi.com> convert-repo <devnull@localhost>
+Kirill Smelkov <kirr@nexedi.com> Kirill Smelkov <kirr@landau.phys.spbu.ru>
 Mateusz Paprocki <mattpap@gmail.com> mattpap <devnull@localhost>
 Fabian Pedregosa <fabian@fseoane.net> Fabian Seoane <fabian@fseoane.net>
 Fabian Pedregosa <fabian@fseoane.net> fabian <fabian@debian.(none)>

--- a/AUTHORS
+++ b/AUTHORS
@@ -17,6 +17,7 @@ Robert Schwarz <lethargo@googlemail.com>
 Pearu Peterson <pearu.peterson@gmail.com>
 Fredrik Johansson <fredrik.johansson@gmail.com>
 Chris Wu <chris.wu@gmail.com>
+Kirill Smelkov <kirr@nexedi.com>
 *Ulrich Hecht <ulrich.hecht@gmail.com>
 Goutham Lakshminarayan <dl.goutham@gmail.com>
 David Lawrence <dmlawrence@gmail.com>

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -52,11 +52,9 @@ All work should be submitted via `Pull Requests (PR)`_.
 License
 -------
 
-By submitting a PR, you agree to license your code under the SymPy's
-`BSD license`_ and `LGPL`_.
+By submitting a PR, you agree to license your code under the `LGPL`_.
 
 
 .. _GitHub issues: https://github.com/skirpichev/omg/issues
 .. _Pull Requests (PR): https://github.com/skirpichev/omg/pulls
-.. _BSD license: LICENSE
 .. _LGPL: https://www.gnu.org/copyleft/lesser.html

--- a/bin/mailmap_update.py
+++ b/bin/mailmap_update.py
@@ -52,7 +52,7 @@ firstauthor = "Ondřej Čertík"
 authors = AUTHORS[AUTHORS.find(firstauthor):].strip().split('\n')
 
 # People who don't want to be listed in AUTHORS
-authors_skip = ["Kirill Smelkov <kirr@landau.phys.spbu.ru>"]
+authors_skip = []
 
 predate_git = 0
 

--- a/doc/aboutus.rst
+++ b/doc/aboutus.rst
@@ -22,6 +22,7 @@ want to be mentioned here, so see our repository history for a full list).
 #. `Pearu Peterson <https://github.com/sympy/sympy/wiki/Pearu-Peterson>`_: new core, sympycore project, general advice (issues and mailinglist)
 #. `Fredrik Johansson <https://github.com/sympy/sympy/wiki/Fredrik-Johansson>`_: mpmath project and its integration in SymPy, number theory, combinatorial functions, products & summation, statistics, units, patches, documentation, general advice (issues and mailinglist)
 #. Chris Wu: GSoC 2007, linear algebra module
+#. Kirill Smelkov: everything, reviewing patches, releases, general advice (issues and mailinglist)
 #. Ulrich Hecht: pattern matching and other patches
 #. Goutham Lakshminarayan: number theory functions
 #. David Lawrence: GHOP, Mathematica parser, square root denesting
@@ -427,7 +428,9 @@ during the summer 2007 as part of the Google Summer of Code (GSoC). Pearu Peters
 joined the development during the summer 2007 and he has made SymPy much more
 competitive by rewriting the core from scratch, that has made it from 10x to
 100x faster. Jurjen N.E. Bos has contributed pretty printing and other patches.
-Fredrik Johansson has wrote mpmath and contributed a lot of patches.
+Fredrik Johansson has wrote mpmath and contributed a lot of patches. Kirill
+Smelkov has joined the development in autumn 2007 and has improved the overall
+quality of SymPy, introduced patch review rules.
 
 SymPy has participated in every GSoC since 2007.  Moderate amount
 of SymPy's development has come from GSoC students.


### PR DESCRIPTION
This reverts commit d02eededb3836d577efe087c9a18b53009c22533.

I'm very positive about additional license restrictions for changes in this
fork (GPL or LGPL, see CONTRIBUTING.rst).  That's why I think I can
revert this shame from the project files.  Emails changed to follow @navytux account.

I hope, Kirill will be ok with all this.
