### PR TITLE
Improve evaluation of Intersection's for FiniteSet with symbolic elements

### DIFF
--- a/sympy/combinatorics/partitions.py
+++ b/sympy/combinatorics/partitions.py
@@ -86,7 +86,7 @@ class Partition(FiniteSet):
         else:
             members = tuple(sorted(self.members,
                              key=lambda w: default_sort_key(w, order)))
-        return list(map(default_sort_key, (self.size, members, self.rank)))
+        return tuple(map(default_sort_key, (self.size, members, self.rank)))
 
     @property
     def partition(self):

--- a/sympy/combinatorics/tests/test_partitions.py
+++ b/sympy/combinatorics/tests/test_partitions.py
@@ -1,8 +1,10 @@
 import pytest
 
+from sympy.core.compatibility import ordered
 from sympy.combinatorics.partitions import (Partition, IntegerPartition,
                                             RGS_enum, RGS_unrank, RGS_rank,
                                             random_integer_partition)
+from sympy.sets.sets import Set
 from sympy.utilities.iterables import default_sort_key, partitions
 
 
@@ -97,3 +99,9 @@ def test_rgs():
     assert RGS_unrank(7, 5) == [0, 0, 1, 0, 2]
     assert RGS_unrank(23, 14) == [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 2, 2]
     assert RGS_rank(RGS_unrank(40, 100)) == 40
+
+
+def test_issue_9608():
+    a = Partition([1, 2, 3], [4])
+    b = Partition([1, 2], [3, 4])
+    assert list(ordered([a, b], Set._infimum_key))  # does not raise an error

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1360,9 +1360,16 @@ class Intersection(Set):
         # all other sets in the intersection
         for s in args:
             if s.is_FiniteSet:
-                return s.func(*[x for x in s
-                                if all(other.contains(x) is S.true
-                                       for other in args)])
+                args = [a for a in args if a != s]
+                res = s.func(*[x for x in s
+                               if all(other.contains(x) is S.true
+                                      for other in args)])
+                unk = [x for x in s
+                       if any(other.contains(x) not in (S.true, S.false)
+                              for other in args)]
+                if unk:
+                    res += Intersection(*([s.func(*unk)] + args), evaluate=False)
+                return res
 
         # If any of the sets are unions, return a Union of Intersections
         for s in args:

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -1303,11 +1303,11 @@ class Intersection(Set):
         if len(args) == 0:
             raise TypeError("Intersection expected at least one argument")
 
+        args = list(ordered(args, Set._infimum_key))
+
         # Reduce sets using known rules
         if evaluate:
             return Intersection.reduce(args)
-
-        args = list(ordered(args, Set._infimum_key))
 
         return Basic.__new__(cls, *args)
 

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -228,7 +228,13 @@ def test_intersect():
     assert Union(Interval(0, 1), Interval(2, 3)).intersect(S.EmptySet) == \
         S.EmptySet
     assert Union(Interval(0, 5), FiniteSet('ham')).intersect(FiniteSet(2, 3, 4, 5, 6)) == \
-        FiniteSet(2, 3, 4, 5)
+        Union(FiniteSet(2, 3, 4, 5), Intersection(FiniteSet(6), Union(Interval(0, 5), FiniteSet('ham'))))
+
+    # issue 8217
+    assert Intersection(FiniteSet(x), FiniteSet(y)) == \
+        Intersection(FiniteSet(x), FiniteSet(y), evaluate=False)
+    assert FiniteSet(x).intersect(S.Reals) == \
+        Intersection(S.Reals, FiniteSet(x), evaluate=False)
 
     # tests for the intersection alias
     assert Interval(0, 5).intersection(FiniteSet(1, 3)) == FiniteSet(1, 3)

--- a/sympy/sets/tests/test_sets.py
+++ b/sympy/sets/tests/test_sets.py
@@ -5,7 +5,7 @@ from sympy import (Symbol, Set, Union, Interval, oo, S, sympify, nan,
                    LessThan, Max, Min, And, Or, Eq, Le,
                    Lt, Float, FiniteSet, Intersection, imageset, I, true, false,
                    ProductSet, sqrt, Complement, EmptySet, sin, cos, Lambda,
-                   ImageSet, pi, Pow, Contains, Sum, RootOf,
+                   ImageSet, pi, Pow, Contains, Sum, RootOf, log,
                    SymmetricDifference, Integer, Rational)
 
 from sympy.abc import a, b, x, y, z
@@ -843,3 +843,8 @@ def test_SymmetricDifference():
 def test_issue_9956():
     assert Union(Interval(-oo, oo), FiniteSet(1)) == Interval(-oo, oo)
     assert Interval(-oo, oo).contains(1) is S.true
+
+
+def test_issue_9536():
+    a = Symbol('a', real=True)
+    assert FiniteSet(log(a)).intersect(S.Reals) == Intersection(S.Reals, FiniteSet(log(a)))

--- a/sympy/stats/rv.py
+++ b/sympy/stats/rv.py
@@ -1042,9 +1042,10 @@ def pspace_independent(a, b):
     pspace_independent(a, b) implies independent(a, b)
     independent(a, b) does not imply pspace_independent(a, b)
     """
-    a_symbols = pspace(b).symbols
-    b_symbols = pspace(a).symbols
-    if len(a_symbols.intersect(b_symbols)) == 0:
+    a_symbols = set(pspace(b).symbols)
+    b_symbols = set(pspace(a).symbols)
+
+    if len(a_symbols.intersection(b_symbols)) == 0:
         return True
     return
 

--- a/sympy/tests/test_wester.py
+++ b/sympy/tests/test_wester.py
@@ -68,8 +68,11 @@ def test_B1():
 
 
 def test_B2():
+    a, b, c = FiniteSet(j), FiniteSet(m), FiniteSet(j, k)
+    d, e = FiniteSet(i), FiniteSet(j, k, l)
+
     assert (FiniteSet(i, j, j, k, k, k) & FiniteSet(l, k, j) &
-            FiniteSet(j, m, j)) == FiniteSet(j)
+            FiniteSet(j, m, j)) == a | (b & (c | (d & e)))
 
 
 def test_B3():


### PR DESCRIPTION
see https://github.com/sympy/sympy/pull/8508

a replacement for https://github.com/skirpichev/omg/pull/11 (travis-ci won't build old pr?)

I believe, we should be more careful for FiniteSet's with symbolic elements also in following cases:
```
In [1]: len(FiniteSet(x, y))
Out[1]: 2
In [2]: for i in FiniteSet(x, y):
   ...:     print(i)
   ...: 
x
y
```
We can iterate over this set only if elements are non-Symbols.