### PR TITLE
Stop brave "simplifications" of complex powers with neg bases

### DIFF
--- a/sympy/simplify/powsimp.py
+++ b/sympy/simplify/powsimp.py
@@ -240,7 +240,7 @@ def powsimp(expr, deep=False, combine='all', force=False, measure=count_ops):
                     return (b, Integer(e.q)), Integer(e.p)
                 else:
                     c, m = e.as_coeff_Mul(rational=True)
-                    if c is not S.One:
+                    if c is not S.One and b.is_positive:
                         return (b**m, Integer(c.q)), Integer(c.p)
                     else:
                         return (b**e, S.One), S.One

--- a/sympy/simplify/tests/test_powsimp.py
+++ b/sympy/simplify/tests/test_powsimp.py
@@ -1,6 +1,7 @@
 from sympy import (
     symbols, powsimp, symbols, MatrixSymbol, sqrt, pi, Mul, gamma, Function,
-    S, I, exp, simplify, sin, E, log, hyper, Symbol, Dummy, powdenest, root)
+    S, I, exp, simplify, sin, E, log, hyper, Symbol, Dummy, powdenest,
+    root, Rational)
 
 from sympy.abc import x, y, z, t, a, b, c, d, e, f, g, h, i, k
 
@@ -286,3 +287,10 @@ def test_issue_from_PR1599():
 
 def test_powsimp_on_numbers():
     assert 2**(S(1)/3 - 2) == 2**(S(1)/3)/4
+
+
+def test_omgissue_124():
+    n = Symbol('n', odd=True)
+    assert powsimp((-1)**(n/2)) in ((-1)**(n/2), I**n)
+    assert powsimp((-1)**(n/2 - Rational(1,2)) -
+                   (-1)**(3*n/2 - Rational(1,2))) != 2  # sympy/sympy#10195


### PR DESCRIPTION
I don't understand this huge mess (i.e. powsimp) in details,
but this simple fix prevents a "simplification" like

    In [1]: powsimp((-1)**(Symbol('n', odd=True)/2))
    Out[1]: I

No action is ok here, but better would be I**n (like Mathematica).

Fixes skirpichev/omg#143
Fixes sympy/sympy#10195