### PR TITLE
Revert redundant return statement, introduced in ea4ff5a

### DIFF
--- a/sympy/simplify/hyperexpand.py
+++ b/sympy/simplify/hyperexpand.py
@@ -2026,7 +2026,7 @@ def _hyperexpand(func, z, ops0=[], z0=Dummy('z0'), premult=1, prem=0,
     p = simplify(p).subs(z0, z)
 
     # Try special expansions early.
-    if unpolarify(z) in [1, -1] and (len(func.ap), len(func.bq)) == (2, 1):
+    if unpolarify(z) in [1, 0, -1]:
         f = build_hypergeometric_formula(func)
         r = carryout_plan(f, ops).replace(hyper, hyperexpand_special)
         if not r.has(hyper):

--- a/sympy/simplify/hyperexpand.py
+++ b/sympy/simplify/hyperexpand.py
@@ -1966,9 +1966,6 @@ def _hyperexpand(func, z, ops0=[], z0=Dummy('z0'), premult=1, prem=0,
     premult must be a*z**prem for some a independent of z.
     """
 
-    if z is S.Zero:
-        return S.One
-
     z = polarify(z, subs=False)
     if rewrite == 'default':
         rewrite = 'nonrepsmall'

--- a/sympy/simplify/tests/test_hyperexpand.py
+++ b/sympy/simplify/tests/test_hyperexpand.py
@@ -1026,3 +1026,4 @@ def test_omgissue_203():
 def test_issue_6052():
     G0 = meijerg((), (), (1,), (0,), 0)
     assert hyperexpand(G0) == 0
+    assert hyperexpand(hyper((), (2,), 0)) == 1

--- a/sympy/simplify/tests/test_hyperexpand.py
+++ b/sympy/simplify/tests/test_hyperexpand.py
@@ -1021,3 +1021,8 @@ def test_omgissue_203():
     assert hyperexpand(h) == Rational(1, 30)
     h = hyper((-6, -7, -5), (-6, -6), 1)
     assert hyperexpand(h) == -Rational(1, 6)
+
+
+def test_issue_6052():
+    G0 = meijerg((), (), (1,), (0,), 0)
+    assert hyperexpand(G0) == 0


### PR DESCRIPTION
This quick exit is not wrong, but redundant.  Meanwhile, there is a real bug (fixed with second commit):
```
In [1]: hyper((), (2,), 0)
Out[1]: 
 ┌─  ⎛  │  ⎞
 ├─  ⎜  │ 0⎟
0╵ 1 ⎝2 │  ⎠

In [2]: hyperexpand(_)
Out[2]: 0

In [3]: Out[1].n()
Out[3]: 1.00000000000000
```

Another problem:
```
In [1]: hyperexpand(hyper((), (2,), z))
Out[1]: 
       ⎛       ___⎞
besseli⎝1, 2⋅╲╱ z ⎠
───────────────────
         ___       
       ╲╱ z        

In [2]: _.subs(z, polar_lift(0))
Out[2]: 0

In [3]: a, b = Integer(0), polar_lift(Integer(0)); a/b
Out[3]: 0
```
Proper fix for this goes to https://github.com/skirpichev/omg/pull/235.